### PR TITLE
fixed make ot build, fixed pyudev, added jenkins_run_cluster

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,8 @@ netifaces==0.10.7
 numpy==1.15.2
 PyYAML==5.1
 PyDispatcher==2.0.5
-usbinfo==1.0.0
+usbinfo==1.1.1
+pyudev==0.21.0
 dpkt==1.9.1
 dispatcher==1.0
 jsonfield==2.0.2

--- a/silk/shell/build_nrf52840.sh
+++ b/silk/shell/build_nrf52840.sh
@@ -21,6 +21,7 @@ date=`date +"%Y-%m-%d"`
 echo 'current date:' $date
 
 cd /home/pi/openthread
+git reset --hard
 
 output=$(git pull | grep "Already up to date")
 
@@ -37,8 +38,14 @@ if [[ $output == *"Already"* ]]; then
 
   ./bootstrap
 
-
-  make -f examples/Makefile-nrf52840 TMF_PROXY=1 BORDER_ROUTER=1 COMMISSIONER=1 USB=1
+  CPPFLAGS="${CPPFLAGS} -DOPENTHREAD_CONFIG_LOG_LEVEL=OT_LOG_LEVEL_INFO"
+  CPPFLAGS="${CPPFLAGS}" make -f examples/Makefile-nrf52840 \
+    BORDER_ROUTER=1 \
+    CHILD_SUPERVISION=1 \
+    LOG_OUTPUT=NCP_SPINEL \
+    MAC_FILTER=1 \
+    REFERENCE_DEVICE=1 \
+    USB=1
 
   echo "Completed buildin, change to output/nrf52840/bin"
   cd output/nrf52840/bin/

--- a/silk/shell/jenkins_run_cluster.sh
+++ b/silk/shell/jenkins_run_cluster.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Script to check build change in a repo and run tests with latest build
+
+function run_test()
+{
+  REPO_NAME=$1
+  CHECK_BUILD_CHANGE=$2
+  source /home/pi/silk/silk/shell/$CHECK_BUILD_CHANGE
+
+echo "******* exporting output variable's value depicting build change from $CHECK_BUILD_CHANGE *******"
+echo $output
+if [[ $output == *"Already"* ]]; then
+  echo "No need to run tests as $REPO_NAME version is same"
+else
+    if [[ $REPO_NAME == "openthread" ]]; then
+      echo "Flash the dev boards with latest ot build"
+      cd /home/pi/silk/silk/shell
+      echo "Getting serial number of dev boards from hwconfig.ini"
+      cat /opt/openthread_test/hwconfig.ini |grep DutSerial|egrep -o [0-9]\{9\} >/opt/openthread_test/serial_num_list.txt
+      for serial_num in $(cat /opt/openthread_test/serial_num_list.txt); do
+          ./nrfjprog.sh --erase-all $serial_num
+          ./nrfjprog.sh --flash /opt/openthread_test/nrf52840_image/ot-ncp-ftd.hex $serial_num
+      done
+    fi
+    echo "Running OT test suite with latest $REPO_NAME version"
+    sudo python /home/pi/silk/silk/unit_tests/silk_run_test.py
+fi
+}
+
+run_test wpantund flash_wpantund.sh
+run_test openthread build_nrf52840.sh
+
+

--- a/silk/unit_tests/silk_run_test.py
+++ b/silk/unit_tests/silk_run_test.py
@@ -20,7 +20,7 @@ RESULT_LOG_PATH = '/opt/openthread_test/results/'+'silk_run_' + \
                   datetime.datetime.today().strftime("%m-%d") + '/'
 CONFIG_PATH = '/opt/openthread_test/'
 
-os.chdir('../tests')
+os.chdir('/home/pi/silk/silk/tests')
 
 timestamp = datetime.datetime.today().strftime("%m-%d-%H:%M")
 


### PR DESCRIPTION
Hi Qilin and Jennie,

Please review this PR it is to fix the following:
1. error seen with make example while running build_nrf52840.sh.
2. usbinfo was not working  with pyudev==0.22.0 switching back to pyudev==0.21.0 fixed it.
3. added support to check both ot and wpantund repo and run ot tests on a cluster.
Please let me know if any changes any improvements are required from my end. 
Thanks in advance.
