### PR TITLE
OTNS Integration: Display Test Title

### DIFF
--- a/silk/tests/testcase.py
+++ b/silk/tests/testcase.py
@@ -244,6 +244,7 @@ def setup_class_decorator(func):
             cls.otns_manager = OtnsManager(
                     server_host=__otns_host,
                     logger=cls.logger.getChild("otnsManager"))
+            cls.otns_manager.set_test_title(cls.__name__)
 
         # Call the user's setUpClass
         try:

--- a/silk/tools/otns_manager.py
+++ b/silk/tools/otns_manager.py
@@ -87,6 +87,16 @@ class GRpcClient:
     self.stub = visualize_grpc_pb2_grpc.VisualizeGrpcServiceStub(self.channel)
     self.logger = logger
 
+  def send_title(self, title: str):
+    """Send test title to OTNS.
+
+    Args:
+        title (str): test title.
+    """
+    response = self.stub.CtrlSetTitle(
+        visualize_grpc_pb2.SetTitleEvent(title=title))
+    self.logger.info("Sent title {:s}, response: {}".format(title, response))
+
   def add_node(self, x: int, y: int, node_id: int, ftd=True,
                rx_on_when_idle=True):
     """Sends an add node request.
@@ -428,6 +438,14 @@ class OtnsManager(object):
     self.logger.info(
         "OTNS manager created, connecting from {:s} to {:s}.".format(
             self.local_host, server_host))
+
+  def set_test_title(self, title: str):
+    """Set title of the test case.
+
+    Args:
+        title (str): title of the test case.
+    """
+    self.grpc_client.send_title(title)
 
   def add_node(self, node: ThreadDevBoard):
     """Add a node to OTNS visualization.

--- a/silk/tools/otns_manager.py
+++ b/silk/tools/otns_manager.py
@@ -87,14 +87,18 @@ class GRpcClient:
     self.stub = visualize_grpc_pb2_grpc.VisualizeGrpcServiceStub(self.channel)
     self.logger = logger
 
-  def send_title(self, title: str):
+  def set_title(self, title: str, x=0, y=20, font_size=20):
     """Send test title to OTNS.
 
     Args:
-        title (str): test title.
+      title (str): test title.
+      x (int): x position of title.
+      y (int): y position of title.
+      font_size (int): font size of title.
     """
     response = self.stub.CtrlSetTitle(
-        visualize_grpc_pb2.SetTitleEvent(title=title))
+        visualize_grpc_pb2.SetTitleEvent(
+            title=title, x=x, y=y, font_size=font_size))
     self.logger.info("Sent title {:s}, response: {}".format(title, response))
 
   def add_node(self, x: int, y: int, node_id: int, ftd=True,
@@ -445,7 +449,7 @@ class OtnsManager(object):
     Args:
         title (str): title of the test case.
     """
-    self.grpc_client.send_title(title)
+    self.grpc_client.set_title(title)
 
   def add_node(self, node: ThreadDevBoard):
     """Add a node to OTNS visualization.

--- a/silk/tools/pb/visualize_grpc.proto
+++ b/silk/tools/pb/visualize_grpc.proto
@@ -55,6 +55,7 @@ message VisualizeEvent {
         SetSpeedEvent set_speed = 18;
         HeartbeatEvent heartbeat = 19;
         OnExtAddrChangeEvent on_ext_addr_change = 20;
+        SetTitleEvent set_title = 21;
     }
 }
 
@@ -179,6 +180,13 @@ message OnExtAddrChangeEvent {
     uint64 ext_addr = 2;
 }
 
+message SetTitleEvent {
+    string title = 1;
+    int32 x = 2;
+    int32 y = 3;
+    int32 font_size = 4;
+}
+
 service VisualizeGrpcService {
     //    rpc Echo (EchoRequest) returns (EchoResponse);
     rpc Visualize (VisualizeRequest) returns (stream VisualizeEvent);
@@ -187,6 +195,7 @@ service VisualizeGrpcService {
     rpc CtrlMoveNodeTo (MoveNodeToRequest) returns (Empty);
     rpc CtrlSetNodeFailed (SetNodeFailedRequest) returns (Empty);
     rpc CtrlSetSpeed (SetSpeedRequest) returns (Empty);
+    rpc CtrlSetTitle (SetTitleEvent) returns (Empty);
 }
 
 message AddNodeRequest {


### PR DESCRIPTION
This PR works alongside https://github.com/openthread/ot-ns/pull/52 to display title of currently running Silk test case name.
![Screenshot from 2020-07-20 14-01-48](https://user-images.githubusercontent.com/66396411/87981011-8306e000-caa2-11ea-8192-639592284294.png)
