### PR TITLE
OTNS Log Replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The `SilkReplayer` allows offline playback of Silk log file for visualization on
 via command line arguments. Usage:
 
 ``` shell
-usage: silk_replay.py [-h] [-d ResPath] [-c ConfFile] [-v X] [-s OtnsServer] P
+usage: silk_replay.py [-h] [-d ResPath] [-c ConfFile] [-v X] [-s OtnsServer] [-p PlaybackSpeed] P
 
 Run a suite of Silk Tests
 positional arguments:
@@ -119,16 +119,16 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -r ResPath, --results_dir ResPath
-                        Set the path for run results
+                        Set the path for run results. Defaults to current folder.
   -c ConfFile, --hwconfig ConfFile
-                        Name the hardware config file
+                        Name the hardware config file. Defaults to `/opt/openthread_test/hwconfig.ini`.
   -v X, --verbose X, --verbosity X
                         Set the verbosity level of the console (0=quiet,
                         1=default, 2=verbose)
   -s OtnsServer, --otns OtnsServer,
-                        Set the OTNS server address to send OTNS messages to
+                        Set the OTNS server address to send OTNS messages to. Defaults to `localhost`.
   -p PlaybackSpeed, --speed PlaybackSpeed,
-                        Speed of log replay
+                        Speed of log replay. e.g. 20 means speeding up to 20x. 1.0 by default.
 ```
 
 There is an example of test run script `silk_replay_test.py` under `unit_tests` folder.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ optional arguments:
                         Set the OTNS server address to send OTNS messages to
 ```
 
-There is an example of test run script `silk_run_test.py` under unit_tests folder.
+There is an example of test run script `silk_run_test.py` under `unit_tests` folder.
 
 ### Using OTNS
 [OpenThread Network Simulator](https://github.com/openthread/ot-ns) is a Thread network visualization and management tool.
@@ -105,6 +105,33 @@ Then follow these steps to use Silk with OTNS:
 2. Flash each board with the images compiled with OpenThread `OTNS=1` flag turned on.
 3. Run OTNS in real mode using `otns -raw -real -ot-cli otns-silk-proxy`.
 4. Run Silk with `silk_run.py`, supplying `-s OtnsServer` argument. If the server is running on the same machine, use `localhost`.
+
+### Using Replayer
+The `SilkReplayer` allows offline playback of Silk log file for visualization on OTNS platform. The playback speed can be controlled
+via command line arguments. Usage:
+
+``` shell
+usage: silk_replay.py [-h] [-d ResPath] [-c ConfFile] [-v X] [-s OtnsServer] P
+
+Run a suite of Silk Tests
+positional arguments:
+  P                     Log file path
+optional arguments:
+  -h, --help            show this help message and exit
+  -r ResPath, --results_dir ResPath
+                        Set the path for run results
+  -c ConfFile, --hwconfig ConfFile
+                        Name the hardware config file
+  -v X, --verbose X, --verbosity X
+                        Set the verbosity level of the console (0=quiet,
+                        1=default, 2=verbose)
+  -s OtnsServer, --otns OtnsServer,
+                        Set the OTNS server address to send OTNS messages to
+  -p PlaybackSpeed, --speed PlaybackSpeed,
+                        Speed of log replay
+```
+
+There is an example of test run script `silk_replay_test.py` under `unit_tests` folder.
 
 ## Build Wpantund image
 

--- a/silk/hw/hw_module.py
+++ b/silk/hw/hw_module.py
@@ -50,7 +50,7 @@ class HwModule(object):
 
     def __init__(self, name, parser, node_id, layout_center=None, layout_radius=None,
                  model=None, interface_serial=None, interface_number=None, port=None,
-                 dut_serial=None, jlink_serial=None):
+                 dut_serial=None, jlink_serial=None, virtual=False):
         self._name = name
         self._parser = parser
         self._claimed = False
@@ -59,15 +59,16 @@ class HwModule(object):
         self._dut_serial = dut_serial
         self._node_id = node_id
 
-        if model and interface_serial and interface_number:
-            if port is None:
-                self.__set_options(model, interface_serial, int(interface_number))
-        elif model or interface_serial or interface_number:
-            raise ValueError("You must specify either all of model, interface_serial and interface_number or none. "
-                             "Provided: %s" % ([model, interface_serial, interface_number]))
+        if not virtual:
+            if model and interface_serial and interface_number:
+                if port is None:
+                    self.__set_options(model, interface_serial, int(interface_number))
+            elif model or interface_serial or interface_number:
+                raise ValueError("You must specify either all of model, interface_serial and interface_number or none. "
+                                "Provided: %s" % ([model, interface_serial, interface_number]))
 
-        if self._port is None:
-            self.set_port()
+            if self._port is None:
+                self.set_port()
         
         assert (layout_center is None) == (layout_radius is None)
         self._layout_center = layout_center

--- a/silk/hw/hw_module.py
+++ b/silk/hw/hw_module.py
@@ -40,6 +40,9 @@ hwNordicSniffer = "NordicSniffer"
 # Silabs Dev Board EFR32
 hwEfr32 = "Efr32"
 
+# Generic Virtual Device (for log replay purpose)
+hwGeneric = "Generic"
+
 dev_devices = [hwNrf52840, hwEfr32, hwNordicSniffer]
 
 

--- a/silk/hw/hw_resource.py
+++ b/silk/hw/hw_resource.py
@@ -44,7 +44,7 @@ class HardwareNotFound(Exception):
 
 
 class HwResource(object):
-    def __init__(self, filename=None, create=False):
+    def __init__(self, filename=None, virtual=False, create=False):
         self._hw_modules = []
         self._thread_sniffer_pool = []
         self._parser = configparser.SafeConfigParser()
@@ -54,6 +54,7 @@ class HwResource(object):
             print('ERROR: No hw config file found at {0}'.format(self._filename))
         
         self._cluster_id = 1
+        self._virtual = virtual
 
     def load_config(self):
         """Returns a Config object from a given INI file"""
@@ -145,7 +146,8 @@ class HwResource(object):
                                     parser=self._parser,
                                     node_id=node_id,
                                     layout_center=self._layout_center,
-                                    layout_radius=self._layout_radius))
+                                    layout_radius=self._layout_radius,
+                                    virtual=self._virtual))
                 except RuntimeError as e:
                     print("Failed to add %s" % device_name)
 
@@ -177,17 +179,17 @@ class HwResource(object):
         Returns:
             List[str]: list of hardware module names.
         """
-        return [module.name for module in self._hw_modules]
+        return [module.name() for module in self._hw_modules]
 
 _global_instance = None
 
 
-def global_instance(filename=None):
+def global_instance(filename=None, virtual=False):
     """ Get the common global instance """
     global _global_instance
 
     if _global_instance is None:
-        _global_instance = HwResource(filename)
+        _global_instance = HwResource(filename, virtual)
 
     return _global_instance
 

--- a/silk/hw/hw_resource.py
+++ b/silk/hw/hw_resource.py
@@ -136,7 +136,7 @@ class HwResource(object):
 
     def _update_hw_modules(self):
         for i, device_name in enumerate(self._parser.sections()):
-            if not self._find_hw_module_by_name(device_name):
+            if not self.find_hw_module_by_name(device_name):
                 node_id = i + 1 + self._cluster_id * CLUSTER_NODE_LIMIT
                 try:
                     self._add_hw_module(
@@ -162,7 +162,7 @@ class HwResource(object):
 
         return None
 
-    def _find_hw_module_by_name(self, name):
+    def find_hw_module_by_name(self, name):
         retval = None
 
         for m in self._hw_modules:

--- a/silk/hw/hw_resource.py
+++ b/silk/hw/hw_resource.py
@@ -34,7 +34,7 @@ layoutCenter = 'LayoutCenter'
 layoutRadius = 'LayoutRadius'
 
 
-class HardwareNotFound(Exception):
+class HardwareNotFoundError(Exception):
     def __init__(self, model, name):
         self.model = model
         self.name = name
@@ -101,7 +101,7 @@ class HwResource(object):
             m = self._find_hw_module_unclaimed_by_model(model)
 
         if not m:
-            raise HardwareNotFound(model, name)
+            raise HardwareNotFoundError(model, name)
         m.claim()
 
         return m

--- a/silk/hw/hw_resource.py
+++ b/silk/hw/hw_resource.py
@@ -34,7 +34,7 @@ layoutCenter = 'LayoutCenter'
 layoutRadius = 'LayoutRadius'
 
 
-class HardwareNotFoundError(Exception):
+class HardwareNotFound(Exception):
     def __init__(self, model, name):
         self.model = model
         self.name = name
@@ -101,7 +101,7 @@ class HwResource(object):
             m = self._find_hw_module_unclaimed_by_model(model)
 
         if not m:
-            raise HardwareNotFoundError(model, name)
+            raise HardwareNotFound(model, name)
         m.claim()
 
         return m
@@ -170,7 +170,14 @@ class HwResource(object):
                 retval = m
 
         return retval
+    
+    def get_hw_module_names(self):
+        """Get the list of names of hardware modules.
 
+        Returns:
+            List[str]: list of hardware module names.
+        """
+        return [module.name for module in self._hw_modules]
 
 _global_instance = None
 

--- a/silk/node/fifteen_four_dev_board.py
+++ b/silk/node/fifteen_four_dev_board.py
@@ -644,4 +644,4 @@ class ThreadDevBoard(FifteenFourDevBoardThreadNode):
             name (str): name of the device to create.
         """
         self.device = silk.hw.hw_resource.global_instance().find_hw_module_by_name(name)
-        self.hwModel = silk.hw.hw_module.hwNrf52840
+        self.hwModel = silk.hw.hw_module.hwGeneric

--- a/silk/node/fifteen_four_dev_board.py
+++ b/silk/node/fifteen_four_dev_board.py
@@ -156,8 +156,8 @@ class FifteenFourDevBoardNode(WpantundWpanNode, NetnsController):
         if not virtual:
             self.log_info('Device Path: {}'.format(self.device_path))
 
-        # Setup netns
-        NetnsController.__init__(self)
+            # Setup netns
+            NetnsController.__init__(self)
 
 #################################
 #   Logging functions

--- a/silk/tests/openthread/ot_test_form_network.py
+++ b/silk/tests/openthread/ot_test_form_network.py
@@ -54,10 +54,6 @@ class TestFormNetwork(testcase.TestCase):
 
         cls.add_test_device(cls.router)
 
-        for end_node in cls.joiner_list[-2:]:
-            end_node.full_thread_device = False
-            end_node.rx_on_when_idle = False
-
         for end_node in cls.joiner_list:
             cls.add_test_device(end_node)
 

--- a/silk/tests/silk_replay.py
+++ b/silk/tests/silk_replay.py
@@ -24,10 +24,12 @@ import sys
 import silk.hw.hw_resource as hw_resource
 from silk.hw.hw_resource import HardwareNotFoundError
 import silk.node.fifteen_four_dev_board as ffdb
-from silk.tools.otns_manager import OtnsManager
+from silk.tools.otns_manager import OtnsManager, RegexType
 
 DATE_FORMAT = "%Y-%m-%d_%H.%M.%S"
 LOG_LINE_FORMAT = "[%(asctime)s] [%(name)s] [%(levelname)s] %(message)s"
+# regex that matches the four components above as groups
+LOG_LINE_REGEX = r"\[([\d\s,:-]+)\] \[([\w\d.-]+)\] \[(\w+)\] (.+)"
 
 
 class SilkReplayer(object):

--- a/silk/tests/silk_replay.py
+++ b/silk/tests/silk_replay.py
@@ -1,0 +1,71 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Silk Test Log Replayer.
+
+Enables replaying Silk log with OTNS enabled through OTNS visualization.
+"""
+
+import argparse
+import logging
+
+import silk.hw.hw_resource as hw_resource
+
+
+class SilkReplayer(object):
+  """Replay topology changes and transmissions from a Silk log.
+
+  Attributes:
+    speed (float): speed ratio for the replay.
+  """
+
+  def __init__(self, argv=None):
+    """Initialize a SilkReplayer.
+
+    Args:
+      argv (List[str], optional): command line arguments. Defaults to None.
+    """
+    args = self.parse_args(argv)
+    self.verbosity = args.verbosity
+    self.log_path = args.path
+    self.speed = args.playback_speed
+
+    hw_resource.global_instance(args.hw_conf_file)
+
+  def parse_args(self, argv):
+    """Parse arguments.
+
+    Args:
+      argv (List[str]): command line arguments.
+
+    Returns:
+      argparse.Namespace: parsed arguments attributes.
+    """
+    parser = argparse.ArgumentParser(description='Replay a Silk test log')
+    parser.add_argument('-c', '--hwconfig', dest='hw_conf_file',
+                        metavar='ConfFile',
+                        help='Name the hardware config file')
+    parser.add_argument('-v', '--verbose', '--verbosity', type=int,
+                        default=1, choices=list(range(0, 3)),
+                        dest='verbosity', metavar='X',
+                        help='Verbosity level (0=quiet, 1=default, 2=verbose)')
+    parser.add_argument('-s', '--otns', dest='otns_server',
+                        metavar='OtnsServer',
+                        help='OTNS server address')
+    parser.add_argument('-p', '--speed', dest='playback_speed',
+                        metavar='PlaybackSpeed',
+                        help='Speed of log replay')
+    parser.add_argument('path', nargs='+', metavar='P',
+                        help='log file path')
+    return parser.parse_args(argv[1:])

--- a/silk/tests/silk_replay.py
+++ b/silk/tests/silk_replay.py
@@ -211,8 +211,12 @@ class SilkReplayer(object):
   def output_summary(self):
     """Print summary of the replayed log.
     """
+    extaddr_table = {}
     for summary in self.otns_manager.node_summaries.values():
-      self.logger.debug(summary)
+      if summary.extaddr_history:
+        extaddr_table[summary.extaddr_history[-1][1]] = summary.node_id
+    for summary in self.otns_manager.node_summaries.values():
+      self.logger.debug(summary.to_string(extaddr_table))
 
   def run(self):
     """Run the Silk log replayer.

--- a/silk/tests/silk_replay.py
+++ b/silk/tests/silk_replay.py
@@ -132,6 +132,7 @@ class SilkReplayer(object):
                         metavar="OtnsServer",
                         help="OTNS server address")
     parser.add_argument("-p", "--speed", dest="playback_speed",
+                        type=float, default=1.0,
                         metavar="PlaybackSpeed",
                         help="Speed of log replay")
     parser.add_argument("path", metavar="P",

--- a/silk/tests/silk_replay.py
+++ b/silk/tests/silk_replay.py
@@ -19,8 +19,15 @@ Enables replaying Silk log with OTNS enabled through OTNS visualization.
 
 import argparse
 import logging
+import sys
 
 import silk.hw.hw_resource as hw_resource
+from silk.hw.hw_resource import HardwareNotFoundError
+import silk.node.fifteen_four_dev_board as ffdb
+from silk.tools.otns_manager import OtnsManager
+
+DATE_FORMAT = "%Y-%m-%d_%H.%M.%S"
+LOG_LINE_FORMAT = "[%(asctime)s] [%(name)s] [%(levelname)s] %(message)s"
 
 
 class SilkReplayer(object):
@@ -28,20 +35,61 @@ class SilkReplayer(object):
 
   Attributes:
     speed (float): speed ratio for the replay.
+    verbosity (int): terminal log verbosity.
+    input_path (str): input Silk log file path.
+    logger (logging.Logger): logger for the replayer.
+
+    devices (List[ThreadDevBoard]): hardware modules from hwconfig.ini file.
+    otns_manager (OtnsManager): manager for OTNS communications.
   """
 
   def __init__(self, argv=None):
-    """Initialize a SilkReplayer.
+    """Initialize a Silk log replayer.
 
     Args:
       argv (List[str], optional): command line arguments. Defaults to None.
     """
     args = self.parse_args(argv)
     self.verbosity = args.verbosity
-    self.log_path = args.path
+    self.input_path = args.path
     self.speed = args.playback_speed
 
+    self.set_up_logger(args.result_path)
+
     hw_resource.global_instance(args.hw_conf_file)
+    self.acquire_devices()
+
+    self.otns_manager = OtnsManager(
+        server_host=args.otns_server,
+        logger=self.logger.getChild("otnsManager"))
+
+  def set_up_logger(self, result_path: str):
+    """Set up logger for the replayer.
+
+    Args:
+      result_path (str): output path of log.
+    """
+    self.logger = logging.getLogger("silk_replay")
+    self.logger.setLevel(logging.DEBUG)
+
+    formatter = logging.Formatter(LOG_LINE_FORMAT)
+
+    file_handler = logging.FileHandler(result_path, mode="w")
+    file_handler.setLevel(logging.DEBUG)
+    file_handler.setFormatter(formatter)
+
+    if self.verbosity == 0:
+      stream_level = logging.CRITICAL
+    elif self.verbosity == 1:
+      stream_level = logging.INFO
+    else:
+      stream_level = logging.DEBUG
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setLevel(stream_level)
+    stream_handler.setFormatter(formatter)
+    self.logger.addHandler(stream_handler)
+    self.logger.addHandler(file_handler)
 
   def parse_args(self, argv):
     """Parse arguments.
@@ -52,20 +100,44 @@ class SilkReplayer(object):
     Returns:
       argparse.Namespace: parsed arguments attributes.
     """
-    parser = argparse.ArgumentParser(description='Replay a Silk test log')
-    parser.add_argument('-c', '--hwconfig', dest='hw_conf_file',
-                        metavar='ConfFile',
-                        help='Name the hardware config file')
-    parser.add_argument('-v', '--verbose', '--verbosity', type=int,
+    parser = argparse.ArgumentParser(description="Replay a Silk test log")
+    parser.add_argument("-r", "--result_path", dest="result_path",
+                        metavar="ResPath",
+                        help="Set the path for run results")
+    parser.add_argument("-c", "--hwconfig", dest="hw_conf_file",
+                        metavar="ConfFile",
+                        help="Name the hardware config file")
+    parser.add_argument("-v", "--verbose", "--verbosity", type=int,
                         default=1, choices=list(range(0, 3)),
-                        dest='verbosity', metavar='X',
-                        help='Verbosity level (0=quiet, 1=default, 2=verbose)')
-    parser.add_argument('-s', '--otns', dest='otns_server',
-                        metavar='OtnsServer',
-                        help='OTNS server address')
-    parser.add_argument('-p', '--speed', dest='playback_speed',
-                        metavar='PlaybackSpeed',
-                        help='Speed of log replay')
-    parser.add_argument('path', nargs='+', metavar='P',
-                        help='log file path')
+                        dest="verbosity", metavar="X",
+                        help="Verbosity level (0=quiet, 1=default, 2=verbose)")
+    parser.add_argument("-s", "--otns", dest="otns_server",
+                        metavar="OtnsServer",
+                        help="OTNS server address")
+    parser.add_argument("-p", "--speed", dest="playback_speed",
+                        metavar="PlaybackSpeed",
+                        help="Speed of log replay")
+    parser.add_argument("path", nargs="+", metavar="P",
+                        help="log file path")
     return parser.parse_args(argv[1:])
+
+  def acquire_devices(self):
+    """Acquire devices from hwconfig.ini file.
+    """
+    while True:
+      try:
+        device = ffdb.ThreadDevBoard()
+      except HardwareNotFoundError:
+        break
+      else:
+        self.devices.append(device)
+
+  def run(self):
+    """Run the Silk log replayer.
+    """
+    with open(file=self.input_path, mode="r") as file:
+      for line in file:
+        print(line)
+
+if __name__ == "__main__":
+  SilkReplayer(argv=sys.argv)

--- a/silk/tests/silk_replay.py
+++ b/silk/tests/silk_replay.py
@@ -71,10 +71,7 @@ class SilkReplayer(object):
     self.input_path = args.path
     self.speed = float(args.playback_speed)
 
-    if args.results_dir is not None:
-      self.set_up_logger(args.results_dir)
-    else:
-      self.set_up_logger(os.getcwd())
+    self.set_up_logger(args.results_dir or os.getcwd())
     self.acquire_devices(args.hw_conf_file)
 
     self.otns_manager = OtnsManager(
@@ -105,7 +102,7 @@ class SilkReplayer(object):
     formatter = logging.Formatter(LOG_LINE_FORMAT)
 
     timestamp = datetime.today().strftime("%m-%d-%H:%M")
-    result_path = result_dir + "/silk_replay_on_{}.log".format(timestamp)
+    result_path = os.path.join(result_dir, "silk_replay_on_{}.log".format(timestamp))
 
     file_handler = logging.FileHandler(result_path, mode="w")
     file_handler.setLevel(logging.DEBUG)

--- a/silk/unit_tests/silk_replay_test.py
+++ b/silk/unit_tests/silk_replay_test.py
@@ -1,0 +1,30 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from silk.tests import silk_replay
+
+CONFIG_PATH = '/opt/openthread_test/'
+
+RESULT_LOG_PATH = '/opt/openthread_test/results/'
+
+argv = [
+    'tests/silk_replay.py',
+    '-v2',
+    '-c', CONFIG_PATH + 'hwconfig.ini',
+    '-s', 'localhost',
+    '-p', '20',
+    RESULT_LOG_PATH + 'test_summary.log'
+]
+
+silk_replay.SilkReplayer(argv=argv)

--- a/silk/unit_tests/silk_replay_test.py
+++ b/silk/unit_tests/silk_replay_test.py
@@ -12,19 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
+
 from silk.tests import silk_replay
 
 CONFIG_PATH = '/opt/openthread_test/'
 
-RESULT_LOG_PATH = '/opt/openthread_test/results/'
+LOG_PATH = '/opt/openthread_test/results/'
+
+timestamp = datetime.datetime.today().strftime('%m-%d-%H:%M')
+
+run_log_path = LOG_PATH + 'silk_replay_on_{}.log' % timestamp
 
 argv = [
     'tests/silk_replay.py',
+    '-r', run_log_path,
     '-v2',
     '-c', CONFIG_PATH + 'hwconfig.ini',
     '-s', 'localhost',
     '-p', '20',
-    RESULT_LOG_PATH + 'test_summary.log'
+    LOG_PATH + 'silk.log'
 ]
 
 silk_replay.SilkReplayer(argv=argv)

--- a/silk/unit_tests/silk_replay_test.py
+++ b/silk/unit_tests/silk_replay_test.py
@@ -12,21 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
-
 from silk.tests import silk_replay
 
 CONFIG_PATH = '/opt/openthread_test/'
-
 LOG_PATH = '/opt/openthread_test/results/'
-
-timestamp = datetime.datetime.today().strftime('%m-%d-%H:%M')
-
-run_log_path = LOG_PATH + 'silk_replay_on_{}.log'.format(timestamp)
 
 argv = [
     'tests/silk_replay.py',
-    '-r', run_log_path,
+    '-r', LOG_PATH,
     '-v2',
     '-c', CONFIG_PATH + 'hwconfig.ini',
     '-s', 'localhost',

--- a/silk/unit_tests/silk_replay_test.py
+++ b/silk/unit_tests/silk_replay_test.py
@@ -31,7 +31,7 @@ argv = [
     '-c', CONFIG_PATH + 'hwconfig.ini',
     '-s', 'localhost',
     '-p', '20',
-    LOG_PATH + 'silk.log'
+    '/home/pi/Documents/silk.log'
 ]
 
 silk_replay.SilkReplayer(argv=argv)

--- a/silk/unit_tests/silk_replay_test.py
+++ b/silk/unit_tests/silk_replay_test.py
@@ -22,7 +22,7 @@ LOG_PATH = '/opt/openthread_test/results/'
 
 timestamp = datetime.datetime.today().strftime('%m-%d-%H:%M')
 
-run_log_path = LOG_PATH + 'silk_replay_on_{}.log' % timestamp
+run_log_path = LOG_PATH + 'silk_replay_on_{}.log'.format(timestamp)
 
 argv = [
     'tests/silk_replay.py',

--- a/silk/unit_tests/silk_run_test.py
+++ b/silk/unit_tests/silk_run_test.py
@@ -21,7 +21,7 @@ RESULT_LOG_PATH = '/opt/openthread_test/results/' + 'silk_run_' + \
                   datetime.datetime.today().strftime('%m-%d') + '/'
 CONFIG_PATH = '/opt/openthread_test/'
 
-os.chdir('/home/pi/silk/silk/tests/')
+os.chdir('/home/tancolin/src/silk/silk/tests/')
 
 timestamp = datetime.datetime.today().strftime('%m-%d-%H:%M')
 
@@ -33,7 +33,7 @@ argv = [
     '-c', CONFIG_PATH + 'hwconfig.ini',
     '-d', run_log_path,
     '-s', 'localhost',
-    'ot_test_*.py'
+    'ot_test_leader_loss.py'
 ]
 
 silk_run.SilkRunner(argv=argv)

--- a/silk/unit_tests/silk_run_test.py
+++ b/silk/unit_tests/silk_run_test.py
@@ -21,7 +21,7 @@ RESULT_LOG_PATH = '/opt/openthread_test/results/' + 'silk_run_' + \
                   datetime.datetime.today().strftime('%m-%d') + '/'
 CONFIG_PATH = '/opt/openthread_test/'
 
-os.chdir('/home/tancolin/src/silk/silk/tests/')
+os.chdir('/home/pi/silk/silk/tests/')
 
 timestamp = datetime.datetime.today().strftime('%m-%d-%H:%M')
 
@@ -33,7 +33,7 @@ argv = [
     '-c', CONFIG_PATH + 'hwconfig.ini',
     '-d', run_log_path,
     '-s', 'localhost',
-    'ot_test_leader_loss.py'
+    'ot_test_*.py'
 ]
 
 silk_run.SilkRunner(argv=argv)


### PR DESCRIPTION
This PR adds `SilkReplayer` which parses a Silk log file and replays it on OTNS web front end.

- Playback speed could be supplied as command line argument.
- Usage added to README.
- Fixes an issue when OTNS feature is disabled.
- Depends on https://github.com/openthread/ot-ns/pull/56 since it removes manual node mode setting in `OtnsManager` and test case.
- Adds managed neighbors and children table for each node to cover test cases where nodes are reset by command.-
- Adds summary to a log replay run, including information about extended address, role, children and neighbors.