### PR TITLE
OTNS Refactor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ grpcio-tools >= 1.30
 ipaddress == 1.0.22
 jsonfield == 2.0.2
 netifaces == 0.10.7
-numpy == 1.15.2
+numpy >= 1.15.4
+pandas >= 1.1.0
 pexpect >= 4.6.0
 protobuf ~= 3.12
 psutil == 5.7.0

--- a/silk/tests/silk_replay.py
+++ b/silk/tests/silk_replay.py
@@ -50,6 +50,7 @@ class SilkReplayer(object):
     speed (float): speed ratio for the replay. 2.0 means speeding up to 2x.
     verbosity (int): terminal log verbosity.
     input_path (str): input Silk log file path.
+    log_filename (str): name of input log file.
     logger (logging.Logger): logger for the replayer.
 
     device_names (Set[str]): name of hardware modules from hwconfig.ini file.
@@ -69,6 +70,7 @@ class SilkReplayer(object):
     args = self.parse_args(argv)
     self.verbosity = args.verbosity
     self.input_path = args.path
+    self.log_filename = os.path.basename(args.path)
     self.speed = float(args.playback_speed)
 
     self.set_up_logger(args.results_dir or os.getcwd())
@@ -81,9 +83,8 @@ class SilkReplayer(object):
     self.last_time = None
     self.run()
 
-    timestamp = datetime.today().strftime("%m-%d-%H:%M")
     result_path = os.path.join(
-        args.results_dir, f"silk_replay_on_{timestamp}.csv")
+        args.results_dir, f"silk_replay_summary_for_{self.log_filename}.csv")
     self.output_summary(coalesced=True, csv_path=result_path)
 
   def set_up_logger(self, result_dir: str):
@@ -106,8 +107,8 @@ class SilkReplayer(object):
 
     formatter = logging.Formatter(LOG_LINE_FORMAT)
 
-    timestamp = datetime.today().strftime("%m-%d-%H:%M")
-    result_path = os.path.join(result_dir, f"silk_replay_on_{timestamp}.log")
+    result_path = os.path.join(
+        result_dir, f"silk_replay_log_for_{self.log_filename}.log")
 
     file_handler = logging.FileHandler(result_path, mode="w")
     file_handler.setLevel(logging.DEBUG)
@@ -224,8 +225,8 @@ class SilkReplayer(object):
     if csv_path:
       collection = OtnsNodeSummaryCollection(
           self.otns_manager.node_summaries.values())
-      df = collection.to_csv(extaddr_map)
-      df.to_csv(csv_path, index=False)
+      data_frame = collection.to_csv(extaddr_map)
+      data_frame.to_csv(csv_path, index=False)
     elif coalesced:
       collection = OtnsNodeSummaryCollection(
           self.otns_manager.node_summaries.values())

--- a/silk/tests/silk_replay.py
+++ b/silk/tests/silk_replay.py
@@ -84,7 +84,7 @@ class SilkReplayer(object):
     timestamp = datetime.today().strftime("%m-%d-%H:%M")
     result_path = os.path.join(
         args.results_dir, f"silk_replay_on_{timestamp}.csv")
-    self.output_summary(True, result_path)
+    self.output_summary(coalesced=True, csv_path=result_path)
 
   def set_up_logger(self, result_dir: str):
     """Set up logger for the replayer.

--- a/silk/tools/otns_manager.py
+++ b/silk/tools/otns_manager.py
@@ -100,6 +100,16 @@ class GRpcClient:
     self.stub = visualize_grpc_pb2_grpc.VisualizeGrpcServiceStub(self.channel)
     self.logger = logger
 
+  def _send_command(self, command: str):
+    """Send a Command gRPC request.
+
+    Args:
+        command (str): command content.
+    """
+    response = self.stub.Command(
+        visualize_grpc_pb2.CommandRequest(command=command))
+    self.logger.info(f"Sent cmd: {command}, resp: {response}".rstrip("\n"))
+
   def set_title(self, title: str, x=0, y=20, font_size=20):
     """Send test title to OTNS.
 
@@ -109,10 +119,7 @@ class GRpcClient:
       y (int): y position of title.
       font_size (int): font size of title.
     """
-    response = self.stub.Command(
-        visualize_grpc_pb2.CommandRequest(
-            command=f"title \"{title}\" x {x} y {y} fs {font_size}"))
-    self.logger.info(f"Sent title {title}, resp: {response}".rstrip("\n"))
+    self._send_command(f"title \"{title}\" x {x} y {y} fs {font_size}")
 
   def set_speed(self, speed: float):
     """Send test replay speed to OTNS.
@@ -120,9 +127,7 @@ class GRpcClient:
     Args:
         speed (float): test replay speed.
     """
-    response = self.stub.Command(
-        visualize_grpc_pb2.CommandRequest(command=f"speed {speed}"))
-    self.logger.info(f"Sent speed {speed}, resp: {response}".rstrip("\n"))
+    self._send_command(f"speed {speed}")
 
   def add_node(self, x: int, y: int, node_id: int):
     """Sends an add node request.
@@ -132,11 +137,7 @@ class GRpcClient:
       y (int): y coordinate of the new node.
       node_id (int): node ID of the new node.
     """
-    response = self.stub.Command(
-        visualize_grpc_pb2.CommandRequest(
-            command=f"add router x {x} y {y} id {node_id}"))
-    self.logger.info(f"Added node {node_id} at x={x}, y={y}, resp: {response}"
-                     .rstrip("\n"))
+    self._send_command(f"add router x {x} y {y} id {node_id}")
 
   def move_node(self, node_id: int, x: int, y: int):
     """Sends a move node request async.
@@ -146,15 +147,7 @@ class GRpcClient:
       x (int): new x coordinate of the node.
       y (int): new y coordianate of the node.
     """
-    def handle_response(request_future):
-      response = request_future.result()
-      self.logger.info(
-          f"Moved node ID={node_id} to x={x}, y={y}, resp: {response}"
-          .rstrip("\n"))
-
-    request_future = self.stub.Command.future(
-        visualize_grpc_pb2.CommandRequest(command=f"move {node_id} {x} {y}"))
-    request_future.add_done_callback(handle_response)
+    self._send_command(f"move {node_id} {x} {y}")
 
   def delete_node(self, node_id: int):
     """Sends a delete node request.
@@ -162,10 +155,7 @@ class GRpcClient:
     Args:
       node_id (int): node ID of the node to be deleted.
     """
-    response = self.stub.Command(
-        visualize_grpc_pb2.CommandRequest(command=f"del {node_id}"))
-    self.logger.info(f"Deleted node ID={node_id}, resp: {response}"
-                     .rstrip("\n"))
+    self._send_command(f"del {node_id}")
 
 
 class Event:

--- a/silk/tools/otns_manager.py
+++ b/silk/tools/otns_manager.py
@@ -887,19 +887,20 @@ class OtnsManager(object):
     Args:
       node (ThreadDevBoard): ThreadDevBoard node.
       message (str): status message.
-      time (datetime.datetime, optional): time of the update. Defaults to
+      time (datetime, optional): time of the update. Defaults to
         datetime.now().
     """
     if node in self.otns_node_map:
       self.update_status(self.otns_node_map[node], message, time=time)
 
-  def update_status(self, node: OtnsNode, message: str, time: datetime):
+  def update_status(self, node: OtnsNode, message: str, time=datetime.now()):
     """Manually update node status with a status message.
 
     Args:
       node (OtnsNode): OTNS node.
       message (str): status message.
-      time (datetime.datetime): time of the update.
+      time (datetime, optional): time of the update. Defaults to
+        datetime.now().
     """
     status_match = re.search(RegexType.STATUS.value, message)
     if status_match:

--- a/silk/tools/otns_manager.py
+++ b/silk/tools/otns_manager.py
@@ -108,9 +108,10 @@ class GRpcClient:
       y (int): y position of title.
       font_size (int): font size of title.
     """
-    response = self.stub.CtrlSetTitle(
-        visualize_grpc_pb2.SetTitleEvent(
-            title=title, x=x, y=y, font_size=font_size))
+    response = self.stub.Command(
+        visualize_grpc_pb2.CommandRequest(
+            command="title \"{:s}\" x {:d} y {:d} fs {:d}".format(
+                title, x, y, font_size)))
     self.logger.info("Sent title {:s}, response: {}".format(title, response))
 
   def add_node(self, x: int, y: int, node_id: int):
@@ -121,18 +122,11 @@ class GRpcClient:
       y (int): y coordinate of the new node.
       node_id (int): node ID of the new node.
     """
-    mode = visualize_grpc_pb2.NodeMode(
-        rx_on_when_idle=True,
-        secure_data_requests=False,
-        full_thread_device=True,
-        full_network_data=False)
-
-    response = self.stub.CtrlAddNode(
-        visualize_grpc_pb2.AddNodeRequest(
-            x=x, y=y, is_router=True, mode=mode, node_id=node_id))
-    self.logger.info(
-        ("Added node {:d} at x={:d}, y={:d}, response: {}").format(
-            node_id, x, y, response))
+    response = self.stub.Command(
+        visualize_grpc_pb2.CommandRequest(
+            command="add router x {:d} y {:d} id {:d}".format(x, y, node_id)))
+    self.logger.info("Added node {:d} at x={:d}, y={:d}, response: {}".format(
+        node_id, x, y, response))
 
   def move_node(self, node_id: int, x: int, y: int):
     """Sends a move node request async.
@@ -148,8 +142,9 @@ class GRpcClient:
           "Moved node ID={:d} to x={:d}, y={:d}, response: {}".format(
               node_id, x, y, response))
 
-    request_future = self.stub.CtrlMoveNodeTo.future(
-        visualize_grpc_pb2.MoveNodeToRequest(node_id=node_id, x=x, y=y))
+    request_future = self.stub.Command.future(
+        visualize_grpc_pb2.CommandRequest(
+            command="move {:d} {:d} {:d}".format(node_id, x, y)))
     request_future.add_done_callback(handle_response)
 
   def delete_node(self, node_id: int):
@@ -158,8 +153,8 @@ class GRpcClient:
     Args:
       node_id (int): node ID of the node to be deleted.
     """
-    response = self.stub.CtrlDeleteNode(
-        visualize_grpc_pb2.DeleteNodeRequest(node_id=node_id))
+    response = self.stub.Command(
+        visualize_grpc_pb2.CommandRequest(command="del {:d}".format(node_id)))
     self.logger.info(
         "Deleted node ID={:d}, response: {}".format(node_id, response))
 

--- a/silk/tools/otns_manager.py
+++ b/silk/tools/otns_manager.py
@@ -106,6 +106,7 @@ class GRpcClient:
     Args:
         command (str): command content.
     """
+    self.logger.info(f"Sending cmd: {command}")
     response = self.stub.Command(
         visualize_grpc_pb2.CommandRequest(command=command))
     self.logger.info(f"Sent cmd: {command}, resp: {response}".rstrip("\n"))

--- a/silk/tools/pb/visualize_grpc.proto
+++ b/silk/tools/pb/visualize_grpc.proto
@@ -28,7 +28,6 @@ syntax = "proto3";
 
 package visualize_grpc_pb;
 
-
 message VisualizeRequest {
 
 }

--- a/silk/tools/pb/visualize_grpc.proto
+++ b/silk/tools/pb/visualize_grpc.proto
@@ -56,6 +56,7 @@ message VisualizeEvent {
         HeartbeatEvent heartbeat = 19;
         OnExtAddrChangeEvent on_ext_addr_change = 20;
         SetTitleEvent set_title = 21;
+        SetNodeModeEvent set_node_mode = 22;
     }
 }
 
@@ -187,6 +188,19 @@ message SetTitleEvent {
     int32 font_size = 4;
 }
 
+message SetNodeModeEvent {
+    int32 node_id = 1;
+    NodeMode node_mode = 2;
+}
+
+message CommandRequest {
+    string command = 1;
+}
+
+message CommandResponse {
+    repeated string output = 1;
+}
+
 service VisualizeGrpcService {
     //    rpc Echo (EchoRequest) returns (EchoResponse);
     rpc Visualize (VisualizeRequest) returns (stream VisualizeEvent);
@@ -196,6 +210,7 @@ service VisualizeGrpcService {
     rpc CtrlSetNodeFailed (SetNodeFailedRequest) returns (Empty);
     rpc CtrlSetSpeed (SetSpeedRequest) returns (Empty);
     rpc CtrlSetTitle (SetTitleEvent) returns (Empty);
+    rpc Command (CommandRequest) returns (CommandResponse);
 }
 
 message AddNodeRequest {


### PR DESCRIPTION
This PR refactors `OtnsManager` and `SilkReplayer` to support new features:
- Coalesced summary format. Instead of displaying summary of each node separately, display a coalesced summary containing events from all nodes.
  - Also supports exporting this summary to a CSV file.
- Setting playback speed for display on OTNS. Allows for proper display and calculation of passed time.
  <img src="https://user-images.githubusercontent.com/66396411/88719888-fab3bb00-d0f1-11ea-89d6-89cb2aab8b6c.png" width="500">
- Use new gRPC `Command` scheme following recent PRs: openthread/ot-ns/pull/61, openthread/ot-ns/pull/64, and openthread/ot-ns/pull/65 that remove old commands.