### PR TITLE
Add OT version display support

### DIFF
--- a/silk/tests/silk_replay.py
+++ b/silk/tests/silk_replay.py
@@ -207,9 +207,16 @@ class SilkReplayer(object):
           device, int(extaddr_match.group(1), 16), time=timestamp)
       return
 
+    ncp_version_match = re.search(OtnsRegexType.NCP_VERSION.value, message)
+    if ncp_version_match:
+      ncp_version = ncp_version_match.group(1)
+      self.otns_manager.set_ncp_version(ncp_version)
+      return
+
     status_match = re.match(OtnsRegexType.STATUS.value, message)
     if status_match:
       self.otns_manager.process_node_status(device, message, time=timestamp)
+      return
 
   def output_summary(self, coalesced: bool, csv_path: str):
     """Print summary of the replayed log.

--- a/silk/tools/otns_manager.py
+++ b/silk/tools/otns_manager.py
@@ -131,15 +131,15 @@ class GRpcClient:
     """
     self._send_command(f"speed {speed}")
 
-  def set_netinfo(self, version: str, commit: str):
+  def set_netinfo(self, version: str=None, commit: str=None):
     """Set OTNS netinfo.
 
     Args:
-      version (str): version string.
-      commit (str): commit string.
+      version (str, optional): version string. Default to None.
+      commit (str, optional): commit string. Default to None.
     """
-    version_clause = f"version \"{version}\"" if version else ""
-    commit_clause = f"commit \"{commit}\"" if commit else ""
+    version_clause = f"version \"{version}\"" if version is not None else ""
+    commit_clause = f"commit \"{commit}\"" if commit is not None else ""
     self._send_command(f"netinfo {version_clause} {commit_clause} real y")
 
   def add_node(self, x: int, y: int, node_id: int):
@@ -990,7 +990,7 @@ class OtnsManager(object):
     ncp_version_match = re.search(RegexType.NCP_VERSION.value, message)
     if ncp_version_match:
       ncp_version = ncp_version_match.group(1)
-      self.grpc_client.set_netinfo(version=ncp_version, commit=None)
+      self.grpc_client.set_netinfo(version=ncp_version)
       return
 
   def set_ncp_version(self, version: str):
@@ -999,7 +999,7 @@ class OtnsManager(object):
     Args:
       version (str): version string.
     """
-    self.grpc_client.set_netinfo(version=version, commit=None)
+    self.grpc_client.set_netinfo(version=version)
 
   def update_extaddr(self, node: ThreadDevBoard,
                      extaddr: int, time=datetime.now()):

--- a/silk/tools/otns_manager.py
+++ b/silk/tools/otns_manager.py
@@ -57,6 +57,7 @@ class RegexType(enum.Enum):
   CHILD_REMOVED_STATUS = r"child_removed=([A-Fa-f0-9]{16})"
   ROUTER_ADDED_STATUS = r"router_added=([A-Fa-f0-9]{16})"
   ROUTER_REMOVED_STATUS = r"router_removed=([A-Fa-f0-9]{16})"
+  NCP_VERSION = r"NCP is running \"(.*)\""
 
 
 class EventType(enum.Enum):
@@ -129,6 +130,17 @@ class GRpcClient:
         speed (float): test replay speed.
     """
     self._send_command(f"speed {speed}")
+
+  def set_netinfo(self, version: str, commit: str):
+    """Set OTNS netinfo.
+
+    Args:
+      version (str): version string.
+      commit (str): commit string.
+    """
+    version_clause = f"version \"{version}\"" if version else ""
+    commit_clause = f"commit \"{commit}\"" if commit else ""
+    self._send_command(f"netinfo {version_clause} {commit_clause} real y")
 
   def add_node(self, x: int, y: int, node_id: int):
     """Sends an add node request.
@@ -973,6 +985,21 @@ class OtnsManager(object):
     if get_extaddr_info_match:
       extaddr = get_extaddr_info_match.group(1)
       node.update_extaddr(int(extaddr, 16))
+      return
+
+    ncp_version_match = re.search(RegexType.NCP_VERSION.value, message)
+    if ncp_version_match:
+      ncp_version = ncp_version_match.group(1)
+      self.grpc_client.set_netinfo(version=ncp_version, commit=None)
+      return
+
+  def set_ncp_version(self, version: str):
+    """Set NCP version for display on OTNS.
+
+    Args:
+      version (str): version string.
+    """
+    self.grpc_client.set_netinfo(version=version, commit=None)
 
   def update_extaddr(self, node: ThreadDevBoard,
                      extaddr: int, time=datetime.now()):

--- a/silk/tools/pb/visualize_grpc.proto
+++ b/silk/tools/pb/visualize_grpc.proto
@@ -56,6 +56,7 @@ message VisualizeEvent {
         OnExtAddrChangeEvent on_ext_addr_change = 20;
         SetTitleEvent set_title = 21;
         SetNodeModeEvent set_node_mode = 22;
+        SetNetworkInfoEvent set_network_info = 23;
     }
 }
 
@@ -192,6 +193,12 @@ message SetNodeModeEvent {
     NodeMode node_mode = 2;
 }
 
+message SetNetworkInfoEvent {
+    bool real = 1;
+    string version = 2;
+    string commit = 3;
+}
+
 message CommandRequest {
     string command = 1;
 }
@@ -203,40 +210,7 @@ message CommandResponse {
 service VisualizeGrpcService {
     //    rpc Echo (EchoRequest) returns (EchoResponse);
     rpc Visualize (VisualizeRequest) returns (stream VisualizeEvent);
-    rpc CtrlAddNode (AddNodeRequest) returns (Empty);
-    rpc CtrlDeleteNode (DeleteNodeRequest) returns (Empty);
-    rpc CtrlMoveNodeTo (MoveNodeToRequest) returns (Empty);
-    rpc CtrlSetNodeFailed (SetNodeFailedRequest) returns (Empty);
-    rpc CtrlSetSpeed (SetSpeedRequest) returns (Empty);
-    rpc CtrlSetTitle (SetTitleEvent) returns (Empty);
     rpc Command (CommandRequest) returns (CommandResponse);
-}
-
-message AddNodeRequest {
-    int32 x = 1;
-    int32 y = 2;
-    bool is_router = 3;
-    NodeMode mode = 4;
-    uint32 node_id = 5;
-}
-
-message DeleteNodeRequest {
-    int32 node_id = 1;
-}
-
-message MoveNodeToRequest {
-    int32 node_id = 1;
-    int32 x = 2;
-    int32 y = 3;
-}
-
-message SetNodeFailedRequest {
-    int32 node_id = 1;
-    bool failed = 2;
-}
-
-message SetSpeedRequest {
-    double speed = 1;
 }
 
 message Empty {


### PR DESCRIPTION
This commit works alongside https://github.com/openthread/ot-ns/pull/70 to add support for displaying NCP version of the test devices.

![Screenshot from 2020-07-30 14-59-32](https://user-images.githubusercontent.com/66396411/88963131-6bcfab80-d275-11ea-895d-01b301fb029c.png)
