### PR TITLE
Fix testcase OTNS Manager check

### DIFF
--- a/silk/tests/testcase.py
+++ b/silk/tests/testcase.py
@@ -344,7 +344,8 @@ def teardown_class_decorator(func):
         output_file.close()
 
         cls.clear_test_devices()
-        cls.otns_manager.unsubscribe_from_all_nodes()
+        if cls.otns_manager:
+            cls.otns_manager.unsubscribe_from_all_nodes()
 
     return wrapper
 


### PR DESCRIPTION
This commit fixes an issue where OTNS manager is missing when OTNS isn't enabled.