### PR TITLE
Syntax Prettify

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,46 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  cancel-previous-runs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: rokroskar/workflow-run-cleanup-action@master
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        if: "github.ref != 'refs/heads/master'"
+  
+  lint:
+    name: Python Lint (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip wheel
+          pip install pylint
+      - name: Lint
+        run: pylint --rcfile=.lintrc silk
+        continue-on-error: true

--- a/.lintrc
+++ b/.lintrc
@@ -1,0 +1,447 @@
+# This Pylint rcfile contains a best-effort configuration to uphold the
+# best-practices and style described in the Google Python style guide:
+#   https://google.github.io/styleguide/pyguide.html
+#
+# Its canonical open-source location is:
+#   https://google.github.io/styleguide/pylintrc
+
+[MASTER]
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=third_party
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=.*grpc_pb2
+
+# Pickle collected data for later comparisons.
+persistent=no
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Use multiple processes to speed up Pylint.
+jobs=4
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=abstract-method,
+        apply-builtin,
+        arguments-differ,
+        attribute-defined-outside-init,
+        backtick,
+        bad-option-value,
+        basestring-builtin,
+        buffer-builtin,
+        c-extension-no-member,
+        consider-using-enumerate,
+        cmp-builtin,
+        cmp-method,
+        coerce-builtin,
+        coerce-method,
+        delslice-method,
+        div-method,
+        duplicate-code,
+        eq-without-hash,
+        execfile-builtin,
+        file-builtin,
+        filter-builtin-not-iterating,
+        fixme,
+        getslice-method,
+        global-statement,
+        hex-method,
+        idiv-method,
+        implicit-str-concat-in-sequence,
+        import-error,
+        import-self,
+        import-star-module-level,
+        inconsistent-return-statements,
+        input-builtin,
+        intern-builtin,
+        invalid-str-codec,
+        locally-disabled,
+        long-builtin,
+        long-suffix,
+        map-builtin-not-iterating,
+        misplaced-comparison-constant,
+        missing-function-docstring,
+        metaclass-assignment,
+        next-method-called,
+        next-method-defined,
+        no-absolute-import,
+        no-else-break,
+        no-else-continue,
+        no-else-raise,
+        no-else-return,
+        no-init,  # added
+        no-member,
+        no-name-in-module,
+        no-self-use,
+        nonzero-method,
+        oct-method,
+        old-division,
+        old-ne-operator,
+        old-octal-literal,
+        old-raise-syntax,
+        parameter-unpacking,
+        print-statement,
+        raising-string,
+        range-builtin-not-iterating,
+        raw_input-builtin,
+        rdiv-method,
+        reduce-builtin,
+        relative-import,
+        reload-builtin,
+        round-builtin,
+        setslice-method,
+        signature-differs,
+        standarderror-builtin,
+        suppressed-message,
+        sys-max-int,
+        too-few-public-methods,
+        too-many-ancestors,
+        too-many-arguments,
+        too-many-boolean-expressions,
+        too-many-branches,
+        too-many-instance-attributes,
+        too-many-locals,
+        too-many-nested-blocks,
+        too-many-public-methods,
+        too-many-return-statements,
+        too-many-statements,
+        trailing-newlines,
+        unichr-builtin,
+        unicode-builtin,
+        unnecessary-pass,
+        unpacking-in-except,
+        useless-else-on-loop,
+        useless-object-inheritance,
+        useless-suppression,
+        using-cmp-argument,
+        wrong-import-order,
+        xrange-builtin,
+        zip-builtin-not-iterating,
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]". This option is deprecated
+# and it will be removed in Pylint 2.0.
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+
+[BASIC]
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=main,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty,cached_property.cached_property,cached_property.threaded_cached_property,cached_property.cached_property_with_ttl,cached_property.threaded_cached_property_with_ttl
+
+# Regular expression matching correct function names
+function-rgx=^(?:(?P<exempt>setUp|tearDown|setUpModule|tearDownModule)|(?P<camel_case>_?[A-Z][a-zA-Z0-9]*)|(?P<snake_case>_?[a-z][a-z0-9_]*))$
+
+# Regular expression matching correct variable names
+variable-rgx=^[a-z][a-z0-9_]*$
+
+# Regular expression matching correct constant names
+const-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
+
+# Regular expression matching correct attribute names
+attr-rgx=^_{0,2}[a-z][a-z0-9_]*$
+
+# Regular expression matching correct argument names
+argument-rgx=^[a-z][a-z0-9_]*$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=^[a-z][a-z0-9_]*$
+
+# Regular expression matching correct class names
+class-rgx=^_?[A-Z][a-zA-Z0-9]*$
+
+# Regular expression matching correct module names
+module-rgx=^(_?[a-z][a-z0-9_]*|__init__)$
+
+# Regular expression matching correct method names
+method-rgx=(?x)^(?:(?P<exempt>_[a-z0-9_]+__|runTest|setUp|tearDown|setUpTestCase|tearDownTestCase|setupSelf|tearDownClass|setUpClass|(test|assert)_*[A-Z0-9][a-zA-Z0-9_]*|next)|(?P<camel_case>_{0,2}[A-Z][a-zA-Z0-9_]*)|(?P<snake_case>_{0,2}[a-z][a-z0-9_]*))$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=(__.*__|main|test.*|.*test|.*Test)$
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=10
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager,contextlib2.contextmanager
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=119
+
+# TODO(https://github.com/PyCQA/pylint/issues/3352): Direct pylint to exempt
+# lines made too long by directives to pytype.
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=(?x)(
+  ^\s*(\#\ )?<?https?://\S+>?$|
+  ^\s*(from\s+\S+\s+)?import\s+.+$)
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=yes
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=
+
+# Maximum number of lines in a module
+max-module-lines=99999
+
+# String used as indentation unit.  The internal Google style guide mandates 2
+# spaces.  Google's externaly-published style guide says 4, consistent with
+# PEP 8.  Here, we use 2 spaces, for conformity with many open-sourced Google
+# projects (like TensorFlow).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=TODO
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=yes
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=^\*{0,2}(_$|unused_|dummy_)
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six,six.moves,past.builtins,future.builtins,functools
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging,absl.logging,tensorflow.io.logging
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,
+                   TERMIOS,
+                   Bastion,
+                   rexec,
+                   sets
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant, absl
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls,
+                            class_
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=StandardError,
+                       Exception,
+                       BaseException

--- a/script/install-dev-deps
+++ b/script/install-dev-deps
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+install_pretty_deps()
+{
+    sudo apt-get install -y shellcheck
+
+    # add yapf for pretty
+    python3 -m pip install yapf==0.29.0 || echo 'WARNING: could not install yapf, which is useful if you plan to contribute python code to the OpenThread project.'
+
+    # add shfmt for shell pretty, try brew only because snap does not support home directory not being /home and doesn't work in docker.
+    command -v shfmt || brew install shfmt || echo 'WARNING: could not install shfmt, which is useful if you plan to contribute shell scripts to the OpenThread project.'
+}
+
+install_pretty_deps

--- a/script/make-pretty
+++ b/script/make-pretty
@@ -1,0 +1,155 @@
+#!/bin/bash
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The script to check or format source code of Silk.
+#
+# Format markdown, python, and shell:
+#
+#     script/make-pretty
+#
+# Format markdown only:
+#
+#     script/make-pretty markdown
+#
+# Format python only:
+#
+#     script/make-pretty python
+#
+# Format shell only:
+#
+#     script/make-pretty shell
+#
+# Check only:
+#
+#     script/make-pretty check markdown
+#     script/make-pretty check python
+#     script/make-pretty check shell
+#
+
+set -euo pipefail
+
+readonly BUILD_JOBS=$(getconf _NPROCESSORS_ONLN)
+readonly EXCLUDE_DIRS=(tools/pb)
+
+readonly MARKDOWN_SOURCES=('*.md')
+readonly PYTHON_SOURCES=('*.py')
+
+do_markdown_format()
+{
+    echo -e '======================'
+    echo -e '     format markdown'
+    echo -e '======================'
+
+    git ls-files "${MARKDOWN_SOURCES[@]}" | grep -v -E "^($(echo "${EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
+        | xargs npx prettier@2.0.4 --write
+}
+
+do_markdown_check()
+{
+    echo -e '======================'
+    echo -e '     check markdown'
+    echo -e '======================'
+
+    git ls-files "${MARKDOWN_SOURCES[@]}" | grep -v -E "^($(echo "${EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
+        | xargs npx prettier@2.0.4 --check
+}
+
+do_python_format()
+{
+    echo -e '======================'
+    echo -e '     format python'
+    echo -e '======================'
+
+    git ls-files "${PYTHON_SOURCES[@]}" | grep -v -E "^($(echo "${EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
+        | xargs python3 -m yapf --verbose --style '{based_on_style: google, column_limit: 119}' -ipr
+}
+
+do_python_check()
+{
+    echo -e '====================='
+    echo -e '     check python'
+    echo -e '====================='
+
+    git ls-files "${PYTHON_SOURCES[@]}" | grep -v -E "^($(echo "${EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
+        | xargs -n10 -P"$BUILD_JOBS" python3 -m yapf --verbose --style '{based_on_style: google, column_limit: 119}' -dpr
+}
+
+do_shell_format()
+{
+    echo -e '====================='
+    echo -e '     format shell'
+    echo -e '====================='
+
+    git ls-files | xargs shfmt -f | grep -v -E "^($(echo "${EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
+        | xargs shfmt -i 4 -bn -ci -fn -s -w
+}
+
+do_shell_check()
+{
+    echo -e '====================='
+    echo -e '     check shell'
+    echo -e '====================='
+
+    git ls-files | xargs shfmt -f | grep -v -E "^($(echo "${EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
+        | xargs shfmt -i 4 -bn -ci -fn -s -d
+
+    git ls-files | xargs shfmt -f | grep -v -E "^($(echo "${EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
+        | xargs shellcheck
+}
+
+do_check()
+{
+    if [ $# == 0 ]; then
+        do_markdown_check
+        do_python_check
+        do_shell_check
+    elif [ "$1" == 'markdown' ]; then
+        do_markdown_check
+    elif [ "$1" == 'python' ]; then
+        do_python_check
+    elif [ "$1" == 'shell' ]; then
+        do_shell_check
+    else
+        echo >&2 "Unsupported check: $1. Supported: markdown, python, shell"
+        # 128 for Invalid arguments
+        exit 128
+    fi
+}
+
+main()
+{
+    if [ $# == 0 ]; then
+        do_markdown_format
+        do_python_format
+        do_shell_format
+    elif [ "$1" == 'markdown' ]; then
+        do_markdown_format
+    elif [ "$1" == 'python' ]; then
+        do_python_format
+    elif [ "$1" == 'shell' ]; then
+        do_shell_format
+    elif [ "$1" == 'check' ]; then
+        shift
+        do_check "$@"
+    else
+        echo >&2 "Unsupported action: $1. Supported: markdown, python, shell"
+        # 128 for Invalid arguments
+        exit 128
+    fi
+
+}
+
+main "$@"

--- a/setup.py
+++ b/setup.py
@@ -20,43 +20,24 @@ from setuptools import find_packages, setup
 exec(open("silk/version.py").read())
 here = os.path.abspath(os.path.dirname(__file__))
 
-setup(name="silk",
-
-      version=__version__,
-
-      description="Openthread testbed",
-
-      # long_description=long_description,
-
-      author="Google Nest, Inc.",
-
-      platforms=["Linux"],
-
-      classifiers=[
-          "Development Status :: 5 - Production/Stable",
-
-          "License :: OSI Approved :: Apache Software License",
-
-          "Intended Audience :: Developers",
-          "Intended Audience :: Education",
-
-          "Operating System :: POSIX :: Linux",
-
-          "Topic :: Software Development :: Testing",
-          "Topic :: Software Development :: Embedded Systems",
-          "Topic :: System :: Emulators",
-          "Topic :: System :: Networking"
-      ],
-
-      license="Apache",
-
-      packages=find_packages(),
-
-      package_data={'silk': ['config/clusters.conf',
-                            'shell/build_nrf52840.sh',
-                            'shell/nrfjprog.sh',
-                            'shell/flash_wpantund.sh',
-                            'shell/shell_wpanctl_cmd.sh',
-                            'shell/git_pull_wpantund.sh',
-                            'shell/shell_scp.sh']},
-      )
+setup(
+    name="silk",
+    version=__version__,
+    description="Openthread testbed",
+    author="Google Nest, Inc.",
+    platforms=["Linux"],
+    classifiers=[
+        "Development Status :: 5 - Production/Stable", "License :: OSI Approved :: Apache Software License",
+        "Intended Audience :: Developers", "Intended Audience :: Education", "Operating System :: POSIX :: Linux",
+        "Topic :: Software Development :: Testing", "Topic :: Software Development :: Embedded Systems",
+        "Topic :: System :: Emulators", "Topic :: System :: Networking"
+    ],
+    license="Apache",
+    packages=find_packages(),
+    package_data={
+        "silk": [
+            "config/clusters.conf", "shell/build_nrf52840.sh", "shell/nrfjprog.sh", "shell/flash_wpantund.sh",
+            "shell/shell_wpanctl_cmd.sh", "shell/git_pull_wpantund.sh", "shell/shell_scp.sh"
+        ]
+    },
+)

--- a/silk/__init__.py
+++ b/silk/__init__.py
@@ -1,4 +1,3 @@
-
 # Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/silk/config/config.py
+++ b/silk/config/config.py
@@ -11,16 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-"""
-config.py
-
-This file contains Configuration management classes for use by the silk framework
+"""This file contains Configuration management classes for use by the silk framework
 
 """
 
-from builtins import str
-from builtins import object
 import json
 
 BLACKLIST_KEY = "blacklist"
@@ -50,7 +44,7 @@ class Config(object):
         Load configuration data from file
         """
         try:
-            with open(self.config_file,'r') as fd:
+            with open(self.config_file, "r") as fd:
                 try:
                     raw_dict = json.load(fd)
                 except ValueError:
@@ -70,11 +64,8 @@ class Config(object):
         """
         Save configuration data to file
         """
-        with open(self.config_file, 'w') as fd:
-            raw_dict = {
-                BLACKLIST_KEY : self.get_blacklist(),
-                PORT_MAPPING : self._get_port_mapping()
-            }
+        with open(self.config_file, "w") as fd:
+            raw_dict = {BLACKLIST_KEY: self.get_blacklist(), PORT_MAPPING: self._get_port_mapping()}
 
             json.dump(raw_dict, fd)
 

--- a/silk/config/defaults.py
+++ b/silk/config/defaults.py
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Config defaults.
+"""
 
 DEFAULT_LOG_OUTPUT_DIRECTORY = "/tmp/silk"
-WPANTUND_PATH = "/usr/local/sbin/wpantund "
-WPANCTL_PATH = "/usr/local/bin/wpanctl "
+WPANTUND_PATH = "/usr/local/sbin/wpantund"
+WPANCTL_PATH = "/usr/local/bin/wpanctl"

--- a/silk/config/wpan_constants.py
+++ b/silk/config/wpan_constants.py
@@ -134,36 +134,36 @@ WPAN_CHANNEL_MANAGER_FAVORED_CHANNEL_MASK = "ChannelManager:FavoredChannelMask"
 #-------------------------------------------------------------------------------------------------------------------
 # Valid state values
 
-STATE_UNINITIALIZED = "uninitialized"
-STATE_FAULT = "uninitialized:fault"
-STATE_UPGRADING = "uninitialized:upgrading"
-STATE_DEEP_SLEEP = "offline:deep-sleep"
-STATE_OFFLINE = "offline"
-STATE_COMMISSIONED = "offline:commissioned"
-STATE_ASSOCIATING = "associating"
-STATE_CREDENTIALS_NEEDED = "associating:credentials-needed"
-STATE_ASSOCIATED = "associated"
-STATE_ISOLATED = "associated:no-parent"
-STATE_NETWAKE_ASLEEP = "associated:netwake-asleep"
-STATE_NETWAKE_WAKING = "associated:netwake-waking"
+STATE_UNINITIALIZED = "\"uninitialized\""
+STATE_FAULT = "\"uninitialized:fault\""
+STATE_UPGRADING = "\"uninitialized:upgrading\""
+STATE_DEEP_SLEEP = "\"offline:deep-sleep\""
+STATE_OFFLINE = "\"offline\""
+STATE_COMMISSIONED = "\"offline:commissioned\""
+STATE_ASSOCIATING = "\"associating\""
+STATE_CREDENTIALS_NEEDED = "\"associating:credentials-needed\""
+STATE_ASSOCIATED = "\"associated\""
+STATE_ISOLATED = "\"associated:no-parent\""
+STATE_NETWAKE_ASLEEP = "\"associated:netwake-asleep\""
+STATE_NETWAKE_WAKING = "\"associated:netwake-waking\""
 
 #--------------------------------------------------------------------------------------------------------------------
 # MCU Power state from `WPAN_NCP_MCU_POWER_STATE`
 
-MCU_POWER_STATE_ON = "on"
-MCU_POWER_STATE_LOW_POWER = "low-power"
-MCU_POWER_STATE_OFF = "off"
+MCU_POWER_STATE_ON = "\"on\""
+MCU_POWER_STATE_LOW_POWER = "\"low-power\""
+MCU_POWER_STATE_OFF = "\"off\""
 
 #--------------------------------------------------------------------------------------------------------------------
 # Node types (from `WPAN_NODE_TYPE` property)
 
-NODE_TYPE_UNKNOWN = "unknown"
-NODE_TYPE_LEADER = "leader"
-NODE_TYPE_ROUTER = "router"
-NODE_TYPE_END_DEVICE = "end-device"
-NODE_TYPE_SLEEPY_END_DEVICE = "sleepy-end-device"
-NODE_TYPE_COMMISSIONER = "commissioner"
-NODE_TYPE_NEST_LURKER = "nl-lurker"
+NODE_TYPE_UNKNOWN = "\"unknown\""
+NODE_TYPE_LEADER = "\"leader\""
+NODE_TYPE_ROUTER = "\"router\""
+NODE_TYPE_END_DEVICE = "\"end-device\""
+NODE_TYPE_SLEEPY_END_DEVICE = "\"sleepy-end-device\""
+NODE_TYPE_COMMISSIONER = "\"commissioner\""
+NODE_TYPE_NEST_LURKER = "\"nl-lurker\""
 
 #--------------------------------------------------------------------------------------------------------------------
 # Node types used by `Node.join()`

--- a/silk/config/wpan_constants.py
+++ b/silk/config/wpan_constants.py
@@ -14,180 +14,172 @@
 
 # wpantund properties
 
-WPAN_STATE                                     = 'NCP:State'
-WPAN_NAME                                      = 'Network:Name'
-WPAN_PANID                                     = 'Network:PANID'
-WPAN_XPANID                                    = 'Network:XPANID'
-WPAN_KEY                                       = 'Network:Key'
-WPAN_KEY_INDEX                                 = 'Network:KeyIndex'
-WPAN_CHANNEL                                   = 'NCP:Channel'
-WPAN_HW_ADDRESS                                = 'NCP:HardwareAddress'
-WPAN_EXT_ADDRESS                               = 'NCP:ExtendedAddress'
-WPAN_POLL_INTERVAL                             = 'NCP:SleepyPollInterval'
-WPAN_NODE_TYPE                                 = 'Network:NodeType'
-WPAN_ROLE                                      = 'Network:Role'
-WPAN_PARTITION_ID                              = 'Network:PartitionId'
-WPAN_IS_COMMISSIONED                           = 'Network:IsCommissioned'
-WPAN_NCP_VERSION                               = 'NCP:Version'
-WPAN_NCP_MCU_POWER_STATE                       = "NCP:MCUPowerState"
-WPAN_NCP_MAC_ADDRESS                           = 'NCP:MACAddress'
-WPAN_NETWORK_ALLOW_JOIN                        = 'com.nestlabs.internal:Network:AllowingJoin'
-WPAN_NETWORK_PASSTHRU_PORT                     = 'com.nestlabs.internal:Network:PassthruPort'
-WPAN_RCP_VERSION                               = "POSIXApp:RCPVersion"
+WPAN_STATE = "NCP:State"
+WPAN_NAME = "Network:Name"
+WPAN_PANID = "Network:PANID"
+WPAN_XPANID = "Network:XPANID"
+WPAN_KEY = "Network:Key"
+WPAN_KEY_INDEX = "Network:KeyIndex"
+WPAN_CHANNEL = "NCP:Channel"
+WPAN_HW_ADDRESS = "NCP:HardwareAddress"
+WPAN_EXT_ADDRESS = "NCP:ExtendedAddress"
+WPAN_POLL_INTERVAL = "NCP:SleepyPollInterval"
+WPAN_NODE_TYPE = "Network:NodeType"
+WPAN_ROLE = "Network:Role"
+WPAN_PARTITION_ID = "Network:PartitionId"
+WPAN_IS_COMMISSIONED = "Network:IsCommissioned"
+WPAN_NCP_VERSION = "NCP:Version"
+WPAN_NCP_MCU_POWER_STATE = "NCP:MCUPowerState"
+WPAN_NCP_MAC_ADDRESS = "NCP:MACAddress"
+WPAN_NETWORK_ALLOW_JOIN = "com.nestlabs.internal:Network:AllowingJoin"
+WPAN_NETWORK_PASSTHRU_PORT = "com.nestlabs.internal:Network:PassthruPort"
+WPAN_RCP_VERSION = "POSIXApp:RCPVersion"
 
-WPAN_IP6_LINK_LOCAL_ADDRESS                    = "IPv6:LinkLocalAddress"
-WPAN_IP6_MESH_LOCAL_ADDRESS                    = "IPv6:MeshLocalAddress"
-WPAN_IP6_MESH_LOCAL_PREFIX                     = "IPv6:MeshLocalPrefix"
-WPAN_IP6_ALL_ADDRESSES                         = "IPv6:AllAddresses"
-WPAN_IP6_MULTICAST_ADDRESSES                   = "IPv6:MulticastAddresses"
+WPAN_IP6_LINK_LOCAL_ADDRESS = "IPv6:LinkLocalAddress"
+WPAN_IP6_MESH_LOCAL_ADDRESS = "IPv6:MeshLocalAddress"
+WPAN_IP6_MESH_LOCAL_PREFIX = "IPv6:MeshLocalPrefix"
+WPAN_IP6_ALL_ADDRESSES = "IPv6:AllAddresses"
+WPAN_IP6_MULTICAST_ADDRESSES = "IPv6:MulticastAddresses"
 
-WPAN_THREAD_RLOC16                             = "Thread:RLOC16"
-WPAN_THREAD_ROUTER_ID                          = "Thread:RouterID"
-WPAN_THREAD_LEADER_ADDRESS                     = "Thread:Leader:Address"
-WPAN_THREAD_LEADER_ROUTER_ID                   = "Thread:Leader:RouterID"
-WPAN_THREAD_LEADER_WEIGHT                      = "Thread:Leader:Weight"
-WPAN_THREAD_LEADER_LOCAL_WEIGHT                = "Thread:Leader:LocalWeight"
-WPAN_THREAD_LEADER_NETWORK_DATA                = "Thread:Leader:NetworkData"
-WPAN_THREAD_STABLE_LEADER_NETWORK_DATA         = "Thread:Leader:StableNetworkData"
-WPAN_THREAD_NETWORK_DATA                       = "Thread:NetworkData"
-WPAN_THREAD_CHILD_TABLE                        = "Thread:ChildTable"
-WPAN_THREAD_CHILD_TABLE_ASVALMAP               = "Thread:ChildTable:AsValMap"
-WPAN_THREAD_CHILD_TABLE_ADDRESSES              = "Thread:ChildTable:Addresses"
-WPAN_THREAD_NEIGHBOR_TABLE                     = "Thread:NeighborTable"
-WPAN_THREAD_NEIGHBOR_TABLE_ASVALMAP            = "Thread:NeighborTable:AsValMap"
-WPAN_THREAD_NEIGHBOR_TABLE_ERR_RATES           = "Thread:NeighborTable:ErrorRates"
-WPAN_THREAD_NEIGHBOR_TABLE_ERR_RATES_AVVALMAP  = "Thread:NeighborTable:ErrorRates:AsValMap"
-WPAN_THREAD_ROUTER_TABLE                       = "Thread:RouterTable"
-WPAN_THREAD_ROUTER_TABLE_ASVALMAP              = "Thread:RouterTable:AsValMap"
-WPAN_THREAD_CHILD_TIMEOUT                      = "Thread:ChildTimeout"
-WPAN_THREAD_PARENT                             = "Thread:Parent"
-WPAN_THREAD_PARENT_ASVALMAP                    = "Thread:Parent:AsValMap"
-WPAN_THREAD_NETWORK_DATA_VERSION               = "Thread:NetworkDataVersion"
-WPAN_THREAD_STABLE_NETWORK_DATA                = "Thread:StableNetworkData"
-WPAN_THREAD_STABLE_NETWORK_DATA_VERSION        = "Thread:StableNetworkDataVersion"
-WPAN_THREAD_PREFERRED_ROUTER_ID                = "Thread:PreferredRouterID"
-WPAN_THREAD_COMMISSIONER_ENABLED               = "Thread:Commissioner:Enabled"
-WPAN_THREAD_DEVICE_MODE                        = "Thread:DeviceMode"
-WPAN_THREAD_OFF_MESH_ROUTES                    = "Thread:OffMeshRoutes"
-WPAN_THREAD_ON_MESH_PREFIXES                   = "Thread:OnMeshPrefixes"
-WPAN_THREAD_ROUTER_ROLE_ENABLED                = "Thread:RouterRole:Enabled"
-WPAN_THREAD_CONFIG_FILTER_RLOC_ADDRESSES       = "Thread:Config:FilterRLOCAddresses"
-WPAN_THREAD_ROUTER_UPGRADE_THRESHOLD           = "Thread:RouterUpgradeThreshold"
-WPAN_THREAD_ROUTER_DOWNGRADE_THRESHOLD         = "Thread:RouterDowngradeThreshold"
-WPAN_THREAD_ACTIVE_DATASET                     = "Thread:ActiveDataset"
-WPAN_THREAD_ACTIVE_DATASET_ASVALMAP            = "Thread:ActiveDataset:AsValMap"
-WPAN_THREAD_PENDING_DATASET                    = "Thread:PendingDataset"
-WPAN_THREAD_PENDING_DATASET_ASVALMAP           = "Thread:PendingDataset:AsValMap"
-WPAN_THREAD_ADDRESS_CACHE_TABLE                = "Thread:AddressCacheTable"
-WPAN_THREAD_ADDRESS_CACHE_TABLE_ASVALMAP       = "Thread:AddressCacheTable:AsValMap"
+WPAN_THREAD_RLOC16 = "Thread:RLOC16"
+WPAN_THREAD_ROUTER_ID = "Thread:RouterID"
+WPAN_THREAD_LEADER_ADDRESS = "Thread:Leader:Address"
+WPAN_THREAD_LEADER_ROUTER_ID = "Thread:Leader:RouterID"
+WPAN_THREAD_LEADER_WEIGHT = "Thread:Leader:Weight"
+WPAN_THREAD_LEADER_LOCAL_WEIGHT = "Thread:Leader:LocalWeight"
+WPAN_THREAD_LEADER_NETWORK_DATA = "Thread:Leader:NetworkData"
+WPAN_THREAD_STABLE_LEADER_NETWORK_DATA = "Thread:Leader:StableNetworkData"
+WPAN_THREAD_NETWORK_DATA = "Thread:NetworkData"
+WPAN_THREAD_CHILD_TABLE = "Thread:ChildTable"
+WPAN_THREAD_CHILD_TABLE_ASVALMAP = "Thread:ChildTable:AsValMap"
+WPAN_THREAD_CHILD_TABLE_ADDRESSES = "Thread:ChildTable:Addresses"
+WPAN_THREAD_NEIGHBOR_TABLE = "Thread:NeighborTable"
+WPAN_THREAD_NEIGHBOR_TABLE_ASVALMAP = "Thread:NeighborTable:AsValMap"
+WPAN_THREAD_NEIGHBOR_TABLE_ERR_RATES = "Thread:NeighborTable:ErrorRates"
+WPAN_THREAD_NEIGHBOR_TABLE_ERR_RATES_AVVALMAP = "Thread:NeighborTable:ErrorRates:AsValMap"
+WPAN_THREAD_ROUTER_TABLE = "Thread:RouterTable"
+WPAN_THREAD_ROUTER_TABLE_ASVALMAP = "Thread:RouterTable:AsValMap"
+WPAN_THREAD_CHILD_TIMEOUT = "Thread:ChildTimeout"
+WPAN_THREAD_PARENT = "Thread:Parent"
+WPAN_THREAD_PARENT_ASVALMAP = "Thread:Parent:AsValMap"
+WPAN_THREAD_NETWORK_DATA_VERSION = "Thread:NetworkDataVersion"
+WPAN_THREAD_STABLE_NETWORK_DATA = "Thread:StableNetworkData"
+WPAN_THREAD_STABLE_NETWORK_DATA_VERSION = "Thread:StableNetworkDataVersion"
+WPAN_THREAD_PREFERRED_ROUTER_ID = "Thread:PreferredRouterID"
+WPAN_THREAD_COMMISSIONER_ENABLED = "Thread:Commissioner:Enabled"
+WPAN_THREAD_DEVICE_MODE = "Thread:DeviceMode"
+WPAN_THREAD_OFF_MESH_ROUTES = "Thread:OffMeshRoutes"
+WPAN_THREAD_ON_MESH_PREFIXES = "Thread:OnMeshPrefixes"
+WPAN_THREAD_ROUTER_ROLE_ENABLED = "Thread:RouterRole:Enabled"
+WPAN_THREAD_CONFIG_FILTER_RLOC_ADDRESSES = "Thread:Config:FilterRLOCAddresses"
+WPAN_THREAD_ROUTER_UPGRADE_THRESHOLD = "Thread:RouterUpgradeThreshold"
+WPAN_THREAD_ROUTER_DOWNGRADE_THRESHOLD = "Thread:RouterDowngradeThreshold"
+WPAN_THREAD_ACTIVE_DATASET = "Thread:ActiveDataset"
+WPAN_THREAD_ACTIVE_DATASET_ASVALMAP = "Thread:ActiveDataset:AsValMap"
+WPAN_THREAD_PENDING_DATASET = "Thread:PendingDataset"
+WPAN_THREAD_PENDING_DATASET_ASVALMAP = "Thread:PendingDataset:AsValMap"
+WPAN_THREAD_ADDRESS_CACHE_TABLE = "Thread:AddressCacheTable"
+WPAN_THREAD_ADDRESS_CACHE_TABLE_ASVALMAP = "Thread:AddressCacheTable:AsValMap"
 
-WPAN_OT_LOG_LEVEL                              = "OpenThread:LogLevel"
-WPAN_OT_SLAAC_ENABLED                          = "OpenThread:SLAAC:Enabled"
-WPAN_OT_STEERING_DATA_ADDRESS                  = "OpenThread:SteeringData:Address"
-WPAN_OT_STEERING_DATA_SET_WHEN_JOINABLE        = "OpenThread:SteeringData:SetWhenJoinable"
-WPAN_OT_MSG_BUFFER_COUNTERS                    = "OpenThread:MsgBufferCounters"
-WPAN_OT_MSG_BUFFER_COUNTERS_AS_STRING          = "OpenThread:MsgBufferCounters:AsString"
-WPAN_OT_DEBUG_TEST_ASSERT                      = "OpenThread:Debug:TestAssert"
-WPAN_OT_DEBUG_TEST_WATCHDOG                    = "OpenThread:Debug:TestWatchdog"
+WPAN_OT_LOG_LEVEL = "OpenThread:LogLevel"
+WPAN_OT_SLAAC_ENABLED = "OpenThread:SLAAC:Enabled"
+WPAN_OT_STEERING_DATA_ADDRESS = "OpenThread:SteeringData:Address"
+WPAN_OT_STEERING_DATA_SET_WHEN_JOINABLE = "OpenThread:SteeringData:SetWhenJoinable"
+WPAN_OT_MSG_BUFFER_COUNTERS = "OpenThread:MsgBufferCounters"
+WPAN_OT_MSG_BUFFER_COUNTERS_AS_STRING = "OpenThread:MsgBufferCounters:AsString"
+WPAN_OT_DEBUG_TEST_ASSERT = "OpenThread:Debug:TestAssert"
+WPAN_OT_DEBUG_TEST_WATCHDOG = "OpenThread:Debug:TestWatchdog"
 
-WPAN_NCP_COUNTER_ALL_MAC                       = "NCP:Counter:AllMac"
-WPAN_NCP_COUNTER_ALL_MAC_ASVALMAP              = "NCP:Counter:AllMac:AsValMap"
-WPAN_NCP_RSSI                                  = "NCP:RSSI"
-WPAN_NCP_STATE                                 = "NCP:State"
-WPAN_NCP_COUNTER_TX_ERR_CCA                    = "NCP:Counter:TX_ERR_CCA"
-WPAN_NCP_COUNTER_TX_IP_DROPPED                 = 'NCP:Counter:TX_IP_DROPPED'
-WPAN_NCP_COUNTER_TX_PKT_ACKED                  = 'NCP:Counter:TX_PKT_ACKED'
-WPAN_NCP_COUNTER_TX_PKT_DATA_POLL              = "NCP:Counter:TX_PKT_DATA_POLL"
+WPAN_NCP_COUNTER_ALL_MAC = "NCP:Counter:AllMac"
+WPAN_NCP_COUNTER_ALL_MAC_ASVALMAP = "NCP:Counter:AllMac:AsValMap"
+WPAN_NCP_RSSI = "NCP:RSSI"
+WPAN_NCP_STATE = "NCP:State"
+WPAN_NCP_COUNTER_TX_ERR_CCA = "NCP:Counter:TX_ERR_CCA"
+WPAN_NCP_COUNTER_TX_IP_DROPPED = "NCP:Counter:TX_IP_DROPPED"
+WPAN_NCP_COUNTER_TX_PKT_ACKED = "NCP:Counter:TX_PKT_ACKED"
+WPAN_NCP_COUNTER_TX_PKT_DATA_POLL = "NCP:Counter:TX_PKT_DATA_POLL"
 
-WPAN_MAC_WHITELIST_ENABLED                     = "MAC:Whitelist:Enabled"
-WPAN_MAC_WHITELIST_ENTRIES                     = "MAC:Whitelist:Entries"
-WPAN_MAC_WHITELIST_ENTRIES_ASVALMAP            = "MAC:Whitelist:Entries:AsValMap"
-WPAN_MAC_BLACKLIST_ENABLED                     = "MAC:Blacklist:Enabled"
-WPAN_MAC_BLACKLIST_ENTRIES                     = "MAC:Blacklist:Entries"
-WPAN_MAC_BLACKLIST_ENTRIES_ASVALMAP            = "MAC:Blacklist:Entries:AsValMap"
+WPAN_MAC_WHITELIST_ENABLED = "MAC:Whitelist:Enabled"
+WPAN_MAC_WHITELIST_ENTRIES = "MAC:Whitelist:Entries"
+WPAN_MAC_WHITELIST_ENTRIES_ASVALMAP = "MAC:Whitelist:Entries:AsValMap"
+WPAN_MAC_BLACKLIST_ENABLED = "MAC:Blacklist:Enabled"
+WPAN_MAC_BLACKLIST_ENTRIES = "MAC:Blacklist:Entries"
+WPAN_MAC_BLACKLIST_ENTRIES_ASVALMAP = "MAC:Blacklist:Entries:AsValMap"
 
-WPAN_CHILD_SUPERVISION_INTERVAL                = "ChildSupervision:Interval"
-WPAN_CHILD_SUPERVISION_CHECK_TIMEOUT           = "ChildSupervision:CheckTimeout"
+WPAN_CHILD_SUPERVISION_INTERVAL = "ChildSupervision:Interval"
+WPAN_CHILD_SUPERVISION_CHECK_TIMEOUT = "ChildSupervision:CheckTimeout"
 
-WPAN_JAM_DETECTION_STATUS                      = "JamDetection:Status"
-WPAN_JAM_DETECTION_ENABLE                      = "JamDetection:Enable"
-WPAN_JAM_DETECTION_RSSI_THRESHOLD              = "JamDetection:RssiThreshold"
-WPAN_JAM_DETECTION_WINDOW                      = "JamDetection:Window"
-WPAN_JAM_DETECTION_BUSY_PERIOD                 = "JamDetection:BusyPeriod"
-WPAN_JAM_DETECTION_DEBUG_HISTORY_BITMAP        = "JamDetection:Debug:HistoryBitmap"
+WPAN_JAM_DETECTION_STATUS = "JamDetection:Status"
+WPAN_JAM_DETECTION_ENABLE = "JamDetection:Enable"
+WPAN_JAM_DETECTION_RSSI_THRESHOLD = "JamDetection:RssiThreshold"
+WPAN_JAM_DETECTION_WINDOW = "JamDetection:Window"
+WPAN_JAM_DETECTION_BUSY_PERIOD = "JamDetection:BusyPeriod"
+WPAN_JAM_DETECTION_DEBUG_HISTORY_BITMAP = "JamDetection:Debug:HistoryBitmap"
 
-WPAN_CHANNEL_MONITOR_SAMPLE_INTERVAL           = "ChannelMonitor:SampleInterval"
-WPAN_CHANNEL_MONITOR_RSSI_THRESHOLD            = "ChannelMonitor:RssiThreshold"
-WPAN_CHANNEL_MONITOR_SAMPLE_WINDOW             = "ChannelMonitor:SampleWindow"
-WPAN_CHANNEL_MONITOR_SAMPLE_COUNT              = "ChannelMonitor:SampleCount"
-WPAN_CHANNEL_MONITOR_CHANNEL_QUALITY           = "ChannelMonitor:ChannelQuality"
-WPAN_CHANNEL_MONITOR_CHANNEL_QUALITY_ASVALMAP  = "ChannelMonitor:ChannelQuality:AsValMap"
+WPAN_CHANNEL_MONITOR_SAMPLE_INTERVAL = "ChannelMonitor:SampleInterval"
+WPAN_CHANNEL_MONITOR_RSSI_THRESHOLD = "ChannelMonitor:RssiThreshold"
+WPAN_CHANNEL_MONITOR_SAMPLE_WINDOW = "ChannelMonitor:SampleWindow"
+WPAN_CHANNEL_MONITOR_SAMPLE_COUNT = "ChannelMonitor:SampleCount"
+WPAN_CHANNEL_MONITOR_CHANNEL_QUALITY = "ChannelMonitor:ChannelQuality"
+WPAN_CHANNEL_MONITOR_CHANNEL_QUALITY_ASVALMAP = "ChannelMonitor:ChannelQuality:AsValMap"
 
-WPAN_CHANNEL_MANAGER_NEW_CHANNEL               = "ChannelManager:NewChannel"
-WPAN_CHANNEL_MANAGER_DELAY                     = "ChannelManager:Delay"
-WPAN_CHANNEL_MANAGER_CHANNEL_SELECT            = "ChannelManager:ChannelSelect"
-WPAN_CHANNEL_MANAGER_AUTO_SELECT_ENABLED       = "ChannelManager:AutoSelect:Enabled"
-WPAN_CHANNEL_MANAGER_AUTO_SELECT_INTERVAL      = "ChannelManager:AutoSelect:Interval"
-WPAN_CHANNEL_MANAGER_SUPPORTED_CHANNEL_MASK    = "ChannelManager:SupportedChannelMask"
-WPAN_CHANNEL_MANAGER_FAVORED_CHANNEL_MASK      = "ChannelManager:FavoredChannelMask"
+WPAN_CHANNEL_MANAGER_NEW_CHANNEL = "ChannelManager:NewChannel"
+WPAN_CHANNEL_MANAGER_DELAY = "ChannelManager:Delay"
+WPAN_CHANNEL_MANAGER_CHANNEL_SELECT = "ChannelManager:ChannelSelect"
+WPAN_CHANNEL_MANAGER_AUTO_SELECT_ENABLED = "ChannelManager:AutoSelect:Enabled"
+WPAN_CHANNEL_MANAGER_AUTO_SELECT_INTERVAL = "ChannelManager:AutoSelect:Interval"
+WPAN_CHANNEL_MANAGER_SUPPORTED_CHANNEL_MASK = "ChannelManager:SupportedChannelMask"
+WPAN_CHANNEL_MANAGER_FAVORED_CHANNEL_MASK = "ChannelManager:FavoredChannelMask"
 
 #-------------------------------------------------------------------------------------------------------------------
 # Valid state values
 
-STATE_UNINITIALIZED                            =  '"uninitialized"'
-STATE_FAULT                                    =  '"uninitialized:fault"'
-STATE_UPGRADING                                =  '"uninitialized:upgrading"'
-STATE_DEEP_SLEEP                               =  '"offline:deep-sleep"'
-STATE_OFFLINE                                  =  '"offline"'
-STATE_COMMISSIONED                             =  '"offline:commissioned"'
-STATE_ASSOCIATING                              =  '"associating"'
-STATE_CREDENTIALS_NEEDED                       =  '"associating:credentials-needed"'
-STATE_ASSOCIATED                               =  '"associated"'
-STATE_ISOLATED                                 =  '"associated:no-parent"'
-STATE_NETWAKE_ASLEEP                           =  '"associated:netwake-asleep"'
-STATE_NETWAKE_WAKING                           =  '"associated:netwake-waking"'
+STATE_UNINITIALIZED = "uninitialized"
+STATE_FAULT = "uninitialized:fault"
+STATE_UPGRADING = "uninitialized:upgrading"
+STATE_DEEP_SLEEP = "offline:deep-sleep"
+STATE_OFFLINE = "offline"
+STATE_COMMISSIONED = "offline:commissioned"
+STATE_ASSOCIATING = "associating"
+STATE_CREDENTIALS_NEEDED = "associating:credentials-needed"
+STATE_ASSOCIATED = "associated"
+STATE_ISOLATED = "associated:no-parent"
+STATE_NETWAKE_ASLEEP = "associated:netwake-asleep"
+STATE_NETWAKE_WAKING = "associated:netwake-waking"
 
-#-----------------------------------------------------------------------------------------------------------------------
+#--------------------------------------------------------------------------------------------------------------------
 # MCU Power state from `WPAN_NCP_MCU_POWER_STATE`
 
-MCU_POWER_STATE_ON                             = '"on"'
-MCU_POWER_STATE_LOW_POWER                      = '"low-power"'
-MCU_POWER_STATE_OFF                            = '"off"'
+MCU_POWER_STATE_ON = "on"
+MCU_POWER_STATE_LOW_POWER = "low-power"
+MCU_POWER_STATE_OFF = "off"
 
-#-----------------------------------------------------------------------------------------------------------------------
+#--------------------------------------------------------------------------------------------------------------------
 # Node types (from `WPAN_NODE_TYPE` property)
 
-NODE_TYPE_UNKNOWN                              = '"unknown"'
-NODE_TYPE_LEADER                               = '"leader"'
-NODE_TYPE_ROUTER                               = '"router"'
-NODE_TYPE_END_DEVICE                           = '"end-device"'
-NODE_TYPE_SLEEPY_END_DEVICE                    = '"sleepy-end-device"'
-NODE_TYPE_COMMISSIONER                         = '"commissioner"'
-NODE_TYPE_NEST_LURKER                          = '"nl-lurker"'
+NODE_TYPE_UNKNOWN = "unknown"
+NODE_TYPE_LEADER = "leader"
+NODE_TYPE_ROUTER = "router"
+NODE_TYPE_END_DEVICE = "end-device"
+NODE_TYPE_SLEEPY_END_DEVICE = "sleepy-end-device"
+NODE_TYPE_COMMISSIONER = "commissioner"
+NODE_TYPE_NEST_LURKER = "nl-lurker"
 
-#-----------------------------------------------------------------------------------------------------------------------
+#--------------------------------------------------------------------------------------------------------------------
 # Node types used by `Node.join()`
 
-JOIN_TYPE_ROUTER                               = 'r'
-JOIN_TYPE_END_DEVICE                           = 'e'
-JOIN_TYPE_SLEEPY_END_DEVICE                    = 's'
+JOIN_TYPE_ROUTER = "r"
+JOIN_TYPE_END_DEVICE = "e"
+JOIN_TYPE_SLEEPY_END_DEVICE = "s"
 
-#-----------------------------------------------------------------------------------------------------------------------
+#--------------------------------------------------------------------------------------------------------------------
 # Bit Flags for Thread Device Mode `WPAN_THREAD_DEVICE_MODE`
 
-THREAD_MODE_FLAG_FULL_NETWORK_DATA   = (1 << 0)
-THREAD_MODE_FLAG_FULL_THREAD_DEV     = (1 << 1)
+THREAD_MODE_FLAG_FULL_NETWORK_DATA = (1 << 0)
+THREAD_MODE_FLAG_FULL_THREAD_DEV = (1 << 1)
 THREAD_MODE_FLAG_SECURE_DATA_REQUEST = (1 << 2)
-THREAD_MODE_FLAG_RX_ON_WHEN_IDLE     = (1 << 3)
+THREAD_MODE_FLAG_RX_ON_WHEN_IDLE = (1 << 3)
 
-#-----------------------------------------------------------------------------------------------------------------------
+#--------------------------------------------------------------------------------------------------------------------
 # thread roles
-ROLES = {
-            "router": 2,
-            "end-node": 3,
-            "sleepy-end-device": 4,
-            2: "router",
-            3: "end-node",
-            4: "sleepy-end-device"
-        }
-
+ROLES = {"router": 2, "end-node": 3, "sleepy-end-device": 4, 2: "router", 3: "end-node", 4: "sleepy-end-device"}

--- a/silk/device/message_item.py
+++ b/silk/device/message_item.py
@@ -11,14 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 message_item.py
 
 This module provides a base class for message items processed by the embedded shell and system call manager
 """
-
-from builtins import object
 
 
 class MessageItemDelegates(object):
@@ -36,7 +33,7 @@ class MessageItemDelegates(object):
 
     # Perform an expect
     # See arguments in envision.Envision
-    def expect(self, expect_list, timeout = None):
+    def expect(self, expect_list, timeout=None):
         return self.expect_handler(self.instance, expect_list, timeout)
 
     # Perform a send
@@ -52,7 +49,8 @@ class MessageItemDelegates(object):
 
 class MessageItemBase(object):
     """
-    Base class used to encapsulate message/work objects handled by EmbeddedShell's message queue
+    Base class used to encapsulate message/work objects handled
+    by EmbeddedShell's message queue
     """
 
     def __init__(self):
@@ -64,20 +62,19 @@ class MessageItemBase(object):
         self._delegates = delegates
 
     def invoke(self, parent):
-        """ Invoke the action to be taken. 
-            Return true if the worker thread should exit.
-        """
+        """ Invoke the action to be taken.
+      Return true if the worker thread should exit.
+    """
         raise NotImplementedError()
 
 
 class MessageCallableItem(MessageItemBase):
-    """ 
-    Class to encapusulate a command/expect message into the message
-    queue.
-    
-    callable_ must be a method that returns true when action is complete. 
+    """Class to encapusulate a command/expect message into the message queue.
+
+    callable_ must be a method that returns true when action is complete.
     Must not return false indefinitely.
     """
+
     def __init__(self, callable_, args):
         super(MessageCallableItem, self).__init__()
         self.__callable = callable_
@@ -92,7 +89,7 @@ class MessageCallableItem(MessageItemBase):
 
     def invoke(self, parent):
         """ Invoke the action repeatedly via callable method until the callable returns true.
-            Return true if the worker thread should exit.
+        Return true if the worker thread should exit.
         """
         should_exit = False
 
@@ -103,7 +100,7 @@ class MessageCallableItem(MessageItemBase):
 
 
 class MessageExitItem(MessageItemBase):
-    """Class to encapsulate a worker thread exit message into the message queue
+    """Class to encapsulate a worker thread exit message into the message queue.
     """
 
     def __init__(self):

--- a/silk/device/netns_base.py
+++ b/silk/device/netns_base.py
@@ -21,9 +21,9 @@ from silk.node.base_node import BaseNode
 import silk.postprocessing.ip as silk_ip
 
 
-def createLinkPair(interface_1, interface_2):
+def create_link_pair(interface_1, interface_2):
     command = "sudo ip link add name %s " % interface_1
-    command += "type veth peer name %s"   % interface_2
+    command += "type veth peer name %s" % interface_2
 
     proc = subprocess.Popen(command, bufsize=0, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
     return proc.communicate()[0]
@@ -40,7 +40,7 @@ class NetnsController(SystemCallManager):
 
     Classes that inherit from NetnsController
     1) Must provide a self.device_path attribute. (This is used to roll a
-       unique network namespace name.)
+        unique network namespace name.)
     2) Inheriting class must define the following logging methods
         a) log_debug(log_line)
         b) log_info(log_line)
@@ -49,7 +49,7 @@ class NetnsController(SystemCallManager):
         e) log_critical(log_line)
     """
 
-    _hwModel = None
+    _hw_model = None
 
     def __init__(self, netns: str = None, device_path: str = None):
         """
@@ -97,7 +97,7 @@ class NetnsController(SystemCallManager):
 
         command = "sudo ip netns pids %s" % self.netns
         output = self._make_system_call("netns-pids", command, 2).strip()
-        return output.split('\n')
+        return output.split("\n")
 
     def netns_killall(self):
         """
@@ -186,8 +186,7 @@ class NetnsController(SystemCallManager):
         self.make_netns_call_async(command, "", 1, None)
 
     def add_route(self, dest, dest_subnet_length, via_addr, interface_name):
-        command = "ip -6 route add %s/%s via %s dev %s" % (dest, dest_subnet_length,
-                                                           via_addr, interface_name)
+        command = "ip -6 route add %s/%s via %s dev %s" % (dest, dest_subnet_length, via_addr, interface_name)
         self.make_netns_call_async(command, "", 1, None)
 
 
@@ -196,6 +195,7 @@ class StandaloneNetworkNamespace(NetnsController, BaseNode):
     Class to control a standalone network namespace that is not associated
     with a development board.
     """
+
     def __init__(self, netns_name):
         device_path = os.path.join("/dev", netns_name)
         BaseNode.__init__(self, netns_name)
@@ -204,9 +204,11 @@ class StandaloneNetworkNamespace(NetnsController, BaseNode):
     def tear_down(self):
         self.cleanup_netns()
 
+
 #################################
 #   Logging functions
 #################################
+
     def set_logger(self, parent_logger):
         self.logger = parent_logger.getChild(self.netns)
 

--- a/silk/device/system_call_manager.py
+++ b/silk/device/system_call_manager.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import object
 import fcntl
 import os
 import queue
@@ -27,7 +26,7 @@ from silk.node.base_node import BaseNode
 
 
 class MessageSystemCallItem(message_item.MessageItemBase):
-    """Class to encapusulate a system call into the message queue
+    """Class to encapusulate a system call into the message queue.
     """
 
     def __init__(self, action, cmd, expect, timeout, field, refresh=0):
@@ -48,8 +47,7 @@ class MessageSystemCallItem(message_item.MessageItemBase):
         for line in response.splitlines():
             self.parent.log_error(line)
 
-        self._delegates.set_error('{0} not found for cmd:{1}!'.format(
-                                  self.expect, self.action))
+        self._delegates.set_error("{0} not found for cmd:{1}!".format(self.expect, self.action))
 
     def log_response_failure(self):
         self.parent.log_error("Worker failed to execute command.")
@@ -95,6 +93,7 @@ class MessageSystemCallItem(message_item.MessageItemBase):
 
 
 class SystemCallManager(object):
+
     def __init__(self):
         self.__message_queue = queue.Queue()
         self.__event_lock = threading.Lock()
@@ -136,9 +135,7 @@ class SystemCallManager(object):
         self.log_debug(log_line)
         self.log_debug(command)
         try:
-            proc = subprocess.Popen(command, bufsize=0, shell=True,
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.STDOUT)
+            proc = subprocess.Popen(command, bufsize=0, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         except Exception as error:
             self.log_error("Failed to start subprocess: %s" % error)
             self.log_error("\tCommand: %s" % command)
@@ -163,9 +160,9 @@ class SystemCallManager(object):
 
                 # Check the length of the read list to see if there is new data
                 if len(poll_list[0]) > 0:
-                    curr_line += proc.stdout.read(1).decode('utf-8')
+                    curr_line += proc.stdout.read(1).decode("utf-8")
             except Exception as err:
-                print('EXCEPTION:{}'.format(err))
+                print("EXCEPTION:{}".format(err))
                 break
 
             if len(curr_line) > 0 and curr_line[-1] == "\n" and not curr_line.isspace():
@@ -186,11 +183,11 @@ class SystemCallManager(object):
             while True:
                 try:
                     new_char = proc.stdout.read(1)
-                    this_stdout += new_char.decode('utf-8')
+                    this_stdout += new_char.decode("utf-8")
                     if not new_char:
                         break
                 except Exception as err:
-                    print('Exception: {}'.format(err))
+                    print("Exception: {}".format(err))
                     break
             if this_stdout:
                 this_stdout = curr_line + this_stdout
@@ -202,8 +199,7 @@ class SystemCallManager(object):
         return stdout
 
     def __clear_message_queue(self):
-        """Remove all pending messages in queue
-
+        """Remove all pending messages in queue.
         """
         try:
             while True:
@@ -212,17 +208,15 @@ class SystemCallManager(object):
             pass
 
     def __set_error(self, msg):
-        """Post error msg and clear message queue
-
+        """Post error msg and clear message queue.
         """
-        self.log_error('set_error: {0}'.format(msg))
+        self.log_error("set_error: {0}".format(msg))
         self.post_error(msg)
         self.__clear_message_queue()
 
     def __worker_run(self):
         """
-        Consumer thread for serializing and asynchronously handling command
-        inputs and expected returns.
+        Consumer thread for serializing and asynchronously handling command inputs and expected returns.
         Serialize requests to make system calls.
         Make system calls using the _make_system_call method.
         """
@@ -235,10 +229,7 @@ class SystemCallManager(object):
 
             error_handler = lambda me, error_str: me.__set_error(error_str)
 
-            delegates = message_item.MessageItemDelegates(self,
-                                                          None,
-                                                          None,
-                                                          error_handler)
+            delegates = message_item.MessageItemDelegates(self, None, None, error_handler)
 
             item.set_delegates(delegates)
 
@@ -246,10 +237,9 @@ class SystemCallManager(object):
 
 
 class TemporarySystemCallManager(SystemCallManager, BaseNode):
+    """Class that can be used to make simple system calls with timeouts and logging functionality.
     """
-    Class that can be used to make simple system calls with
-    timeouts and logging functionality.
-    """
+
     def __init__(self, name="TemporarySystemCallManager"):
         BaseNode.__init__(self, name)
         SystemCallManager.__init__(self)

--- a/silk/hw/hw_module.py
+++ b/silk/hw/hw_module.py
@@ -11,49 +11,56 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 This module allows tests to change configs, since some parameters specified
 can be changed.
 Configs will be locked when they are read to prevent concurrent use of a
 device.
 """
-from builtins import str
-from builtins import object
 from silk.tools import usbdevice
 
-"""HW Config file options"""
-hwModelOption = 'HwModel'
-hwLinuxPortOption = 'LinuxSerialPort'
-hwMacPortOption = 'MacSerialPort'
-interfaceSerial = 'InterfaceSerialNumber'
-interfaceNumber = 'USBInterfaceNumber'
-dutSerialNumber = 'DutSerial'
-otnsVisPosition = 'OTNSVisPosition'
+# HW Config file options
 
-"""HW Config Models"""
+HW_MODEL_OPTION = "HwModel"
+HW_LINUX_PORT_OPTION = "LinuxSerialPort"
+HW_MAC_PORT_OPTION = "MacSerialPort"
+INTERFACE_SERIAL = "InterfaceSerialNumber"
+INTERFACE_NUMBER = "USBInterfaceNumber"
+DUT_SERIAL_NUMBER = "DutSerial"
+OTNS_VIS_POSITION = "OTNSVisPosition"
+
+# HW Config Models
 
 # Nordic Dev Board NRF52840
-hwNrf52840 = "nRF52840_OpenThread_Device"
-hwNordicSniffer = "NordicSniffer"
+HW_NRF52840 = "nRF52840_OpenThread_Device"
+HW_NORDIC_SNIFFER = "NordicSniffer"
 
 # Silabs Dev Board EFR32
-hwEfr32 = "Efr32"
+HW_EFR32 = "Efr32"
 
 # Generic Virtual Device (for log replay purpose)
-hwGeneric = "Generic"
+HW_GENERIC = "Generic"
 
-dev_devices = [hwNrf52840, hwEfr32, hwNordicSniffer]
+DEV_DEVICES = [HW_NRF52840, HW_EFR32, HW_NORDIC_SNIFFER]
 
 
 class HwModule(object):
-    """
-    Maintains usage of a hardware resource
+    """Maintains usage of a hardware resource.
     """
 
-    def __init__(self, name, parser, node_id, layout_center=None, layout_radius=None,
-                 model=None, interface_serial=None, interface_number=None, port=None,
-                 dut_serial=None, jlink_serial=None, virtual=False):
+    def __init__(self,
+                 name,
+                 parser,
+                 node_id,
+                 layout_center=None,
+                 layout_radius=None,
+                 model=None,
+                 interface_serial=None,
+                 interface_number=None,
+                 port=None,
+                 dut_serial=None,
+                 jlink_serial=None,
+                 virtual=False):
         self._name = name
         self._parser = parser
         self._claimed = False
@@ -67,12 +74,13 @@ class HwModule(object):
                 if port is None:
                     self.__set_options(model, interface_serial, int(interface_number))
             elif model or interface_serial or interface_number:
-                raise ValueError("You must specify either all of model, interface_serial and interface_number or none. "
-                                "Provided: %s" % ([model, interface_serial, interface_number]))
+                raise ValueError(
+                    "You must specify either all of model, interface_serial and interface_number or none. "
+                    "Provided: %s" % ([model, interface_serial, interface_number]))
 
             if self._port is None:
                 self.set_port()
-        
+
         assert (layout_center is None) == (layout_radius is None)
         self._layout_center = layout_center
         self._layout_radius = layout_radius
@@ -82,12 +90,12 @@ class HwModule(object):
 
     def claim(self):
         if self._claimed:
-            raise RuntimeError('HwModule %s already claimed.' % self.name)
+            raise RuntimeError("HwModule %s already claimed." % self.name)
         self._claimed = True
 
     def free(self):
         if self._claimed is False:
-            raise RuntimeError('HwModule %s is not claimed.' % self.name)
+            raise RuntimeError("HwModule %s is not claimed." % self.name)
         self._claimed = False
 
     def name(self):
@@ -97,29 +105,28 @@ class HwModule(object):
         if self._model is not None:
             return self._model
         else:
-            return self.__get_option_str(hwModelOption)
+            return self.__get_option_str(HW_MODEL_OPTION)
 
     def interface_serial(self):
-        return self.__get_option_str(interfaceSerial)
+        return self.__get_option_str(INTERFACE_SERIAL)
 
     def interface_number(self):
-        return int(self.__get_option_float(interfaceNumber))
+        return int(self.__get_option_float(INTERFACE_NUMBER))
 
     def port(self):
         return self._port
 
     def get_dut_serial(self):
-        return self.__get_option_str(dutSerialNumber)
+        return self.__get_option_str(DUT_SERIAL_NUMBER)
 
     def get_otns_vis_position(self):
-        coord_str = self.__get_option_str(otnsVisPosition)
+        coord_str = self.__get_option_str(OTNS_VIS_POSITION)
         parts = coord_str.split(",")
         if len(parts) != 2:
-            raise ValueError(
-                "Node position must have x and y coordinates. Provided: %s" % coord_str)
+            raise ValueError("Node position must have x and y coordinates. Provided: %s" % coord_str)
 
         return int(parts[0]), int(parts[1])
-    
+
     def get_otns_vis_node_id(self):
         return self._node_id
 
@@ -143,29 +150,29 @@ class HwModule(object):
 
         model = self.model()
 
-        if model in dev_devices:
+        if model in DEV_DEVICES:
             self._port = \
-                self.find_dev_board_from_serial(serial_to_find, interface_number, model)
+              self.find_dev_board_from_serial(serial_to_find, interface_number, model)
         else:
-            raise RuntimeError('Device not supported %s' % model)
+            raise RuntimeError("Device not supported %s" % model)
 
         if self._port is None:
-            raise RuntimeError('Device not found %s' % self._name)
+            raise RuntimeError("Device not found %s" % self._name)
 
     def __str__(self):
-        return_string =  '[{!s}]\n'.format(self.name())
-        return_string += 'model: {!s}\n'.format(self.model())
-        return_string += 'port : {!s}\n'.format(self.port())
-        return_string += 'claim: {!s}'.format(self._claimed)
+        return_string = "[{!s}]\n".format(self.name())
+        return_string += "model: {!s}\n".format(self.model())
+        return_string += "port : {!s}\n".format(self.port())
+        return_string += "claim: {!s}".format(self._claimed)
 
         return return_string
 
     def __set_options(self, model, interface_serial, interface_number):
-        self._parser.set(self._name, hwModelOption, model)
-        self._parser.set(self._name, interfaceSerial, interface_serial)
-        self._parser.set(self._name, interfaceNumber, str(interface_number))
+        self._parser.set(self._name, HW_MODEL_OPTION, model)
+        self._parser.set(self._name, INTERFACE_SERIAL, interface_serial)
+        self._parser.set(self._name, INTERFACE_NUMBER, str(interface_number))
 
-    def __get_option_str(self, option, default=''):
+    def __get_option_str(self, option, default=""):
         if self._parser.has_option(self._name, option):
             return self._parser.get(self._name, option)
         return default

--- a/silk/hw/hw_resource.py
+++ b/silk/hw/hw_resource.py
@@ -11,13 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-"""
-This module maintains the set of hardware resources available for testing.
+"""This module maintains the set of hardware resources available for testing.
 """
 
-from builtins import str
-from builtins import object
 import configparser
 from . import hw_module
 import os.path
@@ -27,23 +23,24 @@ DEFAULT_CONFIG_PATH = os.path.join(silk.tests.__path__[0], "hwconfig.ini")
 
 CLUSTER_NODE_LIMIT = 50
 CLUSTER_LIMIT = 20
-
 """HW Config file options"""
-clusterID = 'ClusterID'
-layoutCenter = 'LayoutCenter'
-layoutRadius = 'LayoutRadius'
+clusterID = "ClusterID"
+layoutCenter = "LayoutCenter"
+layoutRadius = "LayoutRadius"
 
 
 class HardwareNotFound(Exception):
+
     def __init__(self, model, name):
         self.model = model
         self.name = name
 
     def __str__(self):
-        return 'HW Model {0} not found for {1}'.format(self.model, self.name)
+        return "HW Model {0} not found for {1}".format(self.model, self.name)
 
 
 class HwResource(object):
+
     def __init__(self, filename=None, virtual=False, create=False):
         self._hw_modules = []
         self._thread_sniffer_pool = []
@@ -51,19 +48,20 @@ class HwResource(object):
         self._filename = filename or DEFAULT_CONFIG_PATH
         self._create = create
         if not os.path.isfile(self._filename):
-            print('ERROR: No hw config file found at {0}'.format(self._filename))
-        
+            print("ERROR: No hw config file found at {0}".format(self._filename))
+
         self._cluster_id = 1
         self._virtual = virtual
 
     def load_config(self):
-        """Returns a Config object from a given INI file"""
+        """Returns a Config object from a given INI file.
+        """
         self._create_config_if_needed()
 
         filenames = self._parser.read(self._filename)
         if len(filenames) == 0:
             raise RuntimeError("Failed to load objects from %s. Result %s" % (self._filename, str(filenames)))
-        
+
         self._cluster_id = int(self._parser["DEFAULT"].get(clusterID, "0")) % CLUSTER_LIMIT
 
         default_center_x = (self._cluster_id % 3 + 1) * 200
@@ -72,25 +70,26 @@ class HwResource(object):
         layout_center_string = self._parser["DEFAULT"].get(layoutCenter, default_center)
         layout_center_parts = layout_center_string.split(",")
         if len(layout_center_parts) != 2:
-            raise ValueError(
-                "Center position must have x and y coordinates. Provided: %s" % layout_center_string)
+            raise ValueError("Center position must have x and y coordinates. Provided: %s" % layout_center_string)
 
         self._layout_center = int(layout_center_parts[0]), int(layout_center_parts[1])
         self._layout_radius = int(self._parser["DEFAULT"].get(layoutRadius, "100"))
 
-        print('Found {0} HW Config Resources from {1}...'.format(len(self._parser.sections()), self._filename))
+        print("Found {0} HW Config Resources from {1}...".format(len(self._parser.sections()), self._filename))
         self._update_hw_modules()
-        print('Located {0} Physical Resources...'.format(len(self._hw_modules)))
+        print("Located {0} Physical Resources...".format(len(self._hw_modules)))
 
     def free_hw_module(self, module):
-        """Free a particular module"""
+        """Free a particular module.
+        """
         if module in self._hw_modules:
             module.free()
         else:
-            print('Module %s not found!' % module.name())
+            print("Module %s not found!" % module.name())
 
     def get_hw_module(self, model, sw_version=None, name=None):
-        """Get a particular hardware module"""
+        """Get a particular hardware module.
+        """
         if name is None:
             name = model
 
@@ -108,7 +107,8 @@ class HwResource(object):
         return m
 
     def add_hw_module(self, module_name, model, interface_serial, interface_number):
-        """Add a hardware module to the list of modules"""
+        """Add a hardware module to the list of modules.
+        """
         self._create_config_if_needed()
 
         if not self._parser.has_section(module_name):
@@ -141,13 +141,12 @@ class HwResource(object):
                 node_id = i + 1 + self._cluster_id * CLUSTER_NODE_LIMIT
                 try:
                     self._add_hw_module(
-                            hw_module.HwModule(
-                                    name=device_name,
-                                    parser=self._parser,
-                                    node_id=node_id,
-                                    layout_center=self._layout_center,
-                                    layout_radius=self._layout_radius,
-                                    virtual=self._virtual))
+                        hw_module.HwModule(name=device_name,
+                                           parser=self._parser,
+                                           node_id=node_id,
+                                           layout_center=self._layout_center,
+                                           layout_radius=self._layout_radius,
+                                           virtual=self._virtual))
                 except RuntimeError as e:
                     print("Failed to add %s" % device_name)
 
@@ -172,24 +171,25 @@ class HwResource(object):
                 retval = m
 
         return retval
-    
+
     def get_hw_module_names(self):
         """Get the list of names of hardware modules.
 
         Returns:
-            List[str]: list of hardware module names.
+        List[str]: list of hardware module names.
         """
         return [module.name() for module in self._hw_modules]
+
 
 _global_instance = None
 
 
 def global_instance(filename=None, virtual=False):
-    """ Get the common global instance """
+    """Get the common global instance.
+    """
     global _global_instance
 
     if _global_instance is None:
         _global_instance = HwResource(filename, virtual)
 
     return _global_instance
-

--- a/silk/node/base_node.py
+++ b/silk/node/base_node.py
@@ -11,12 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-"""
-Base class of node profiles
+"""Base class of node profiles.
 """
 
-from builtins import object
 import logging
 import threading
 import queue
@@ -25,52 +22,53 @@ import silk.tools.watchable as watchable
 
 
 def not_implemented(f):
+
     def wrapper(self, *args):
         print("'%s.%s' not implemented" % (self.__class__.__name__, f.__name__))
+
     return wrapper
 
 
 class BaseNode(object):
-    """
-    Base node superclass
+    """Base node superclass.
     """
     _maxTimeout = 60 * 3
 
-    def __init__(self, name='Node'):
+    def __init__(self, name="Node"):
         self._connected = False
         self._name = name
         self._error = queue.Queue(1)
         self._all_clear = threading.Event()
         self._lock = threading.Lock()
         self.__store = dict()
-        self.logger = logging.getLogger('SilkDefault')
+        self.logger = logging.getLogger("SilkDefault")
 
     def __get_log_prefix(self):
         return "%s" % self._name
 
     def log_debug(self, log):
-        """Helper to log debug events
+        """Helper to log debug events.
         """
         line = "DBG: %s: %s" % (self.__get_log_prefix(), log)
         self.logger.debug(line)
 
     def log_info(self, log):
-        """Helper to log info events
+        """Helper to log info events.
         """
         self.logger.info("%s: %s" % (self.__get_log_prefix(), log))
 
     def log_error(self, log):
-        """Helper to log error events
+        """Helper to log error events.
         """
         self.logger.error("ERR: %s: %s" % (self.__get_log_prefix(), log))
 
     def in_error(self):
-        """Returns true if error condition has been set
+        """Returns true if error condition has been set.
         """
         return not self._error.empty()
 
     def get_error(self):
-        """Returns error message and clears error condition, if any
+        """Returns error message and clears error condition, if any.
 
         Returns None if there is no error.
         """
@@ -83,25 +81,24 @@ class BaseNode(object):
     def post_error(self, msg):
         """Posts the error msg if none exists.
         """
-        self.logger.error('Posting error: {0}'.format(msg))
+        self.logger.error(f"Posting error: {msg}")
         try:
             self.log_error(msg)
             self._error.put_nowait(msg)
         except queue.Full:
-            print('{0}: Failed to post error {1}. Already has error'.format(self._name, msg))
+            print(f"{self._name}: Failed to post error {msg}. Already has error")
 
     def set_all_clear(self, is_all_clear):
-        """Update Event to the value of is_all_clear
+        """Update Event to the value of is_all_clear.
 
         Args:
             is_all_clear (bool): Boolean value to assign Event.
 
         This method should only be called with the lock and only on three
         occasions:
-            1: Initially at the start of the daemon (to set event)
-            2: After a message is been processed (set if queue is empty)
-            3: When a message has been queued (to clear event) 
-
+        1: Initially at the start of the daemon (to set event)
+        2: After a message is been processed (set if queue is empty)
+        3: When a message has been queued (to clear event) 
         """
 
         self.log_debug("Setting all-clear to %s" % is_all_clear)
@@ -116,7 +113,7 @@ class BaseNode(object):
         """
         self._all_clear.wait(self._maxTimeout)
         if not self._all_clear.is_set():
-            self.log_debug('Did not get an all-clear!')
+            self.log_debug("Did not get an all-clear!")
         return self.get_error()
 
     def store_data(self, value, field):
@@ -148,7 +145,7 @@ class BaseNode(object):
         # Convert to desired type
         if to_type is not None:
             try:
-                if to_type == 'hex-int':
+                if to_type == "hex-int":
                     value = int(value, 16)
                 else:
                     value = to_type(value)
@@ -166,7 +163,7 @@ class BaseNode(object):
 
     @property
     def ip6_lla_label(self):
-        return 'ip6_lla'
+        return "ip6_lla"
 
     @property
     def ip6_lla(self):
@@ -175,7 +172,7 @@ class BaseNode(object):
 
     @property
     def ip6_mla_label(self):
-        return 'ip6_mla'
+        return "ip6_mla"
 
     @property
     def ip6_mla(self):
@@ -184,7 +181,7 @@ class BaseNode(object):
 
     @property
     def ping6_sent_label(self):
-        return 'ping6_sent'
+        return "ping6_sent"
 
     @property
     def ping6_sent(self):
@@ -193,7 +190,7 @@ class BaseNode(object):
 
     @property
     def ping6_received_label(self):
-        return 'ping6_received'
+        return "ping6_received"
 
     @property
     def ping6_received(self):
@@ -202,7 +199,7 @@ class BaseNode(object):
 
     @property
     def ping6_results_label(self):
-        return 'ping6_results'
+        return "ping6_results"
 
     def ping6_results_process(self):
         match_results = self.get_data(self.ping6_results_label)
@@ -227,7 +224,7 @@ class BaseNode(object):
     @not_implemented
     def set_up(self):
         """Perform all hardware and software set-up to ready the node.
-        """
+    """
         pass
 
     @not_implemented
@@ -237,7 +234,7 @@ class BaseNode(object):
         pass
 
     def set_logger(self, parent_logger):
-        """Set logger to a child from parent_logger
+        """Set logger to a child from parent_logger.
         """
         self.logger = parent_logger.getChild(self._name)
         self.logger.setLevel(logging.DEBUG)
@@ -247,37 +244,34 @@ class BaseNode(object):
 
         Store results in ping6_sent and ping6_received
         """
-        pass        
+        pass
 
     @not_implemented
     def reset_thread_radio(self):
-        """Reset the node's thread radio
+        """Reset the node's thread radio.
         """
         pass
 
     @not_implemented
     def reset_host_cpu(self, reset_thread_radio=False):
-        """Reset the node host (with or w/o radio)
+        """Reset the node host (with or w/o radio).
         """
         pass
 
     @not_implemented
     def firmware_version(self):
-        """
-        Query node's firmware version.
+        """Query node's firmware version.
         """
         return None
 
     @not_implemented
     def firmware_update(self, fw_file):
-        """
-        Update the node's firmware.
+        """Update the node's firmware.
         """
         pass
 
     @not_implemented
     def clear_state(self):
-        """
-        Clear any persistent state in the node.
+        """Clear any persistent state in the node.
         """
         pass

--- a/silk/node/fifteen_four_dev_board.py
+++ b/silk/node/fifteen_four_dev_board.py
@@ -558,7 +558,7 @@ class FifteenFourDevBoardNode(WpantundWpanNode, NetnsController):
         NOTE: this method uses linux `ip` command.
         """
         interface = self.thread_interface
-        cmd = f"ip -6 address add {address} /{prefix_len} dev {interface}"
+        cmd = f"ip -6 address add {address}/{prefix_len} dev {interface}"
         result = self.make_netns_call(cmd, 15)
 
         return result
@@ -570,7 +570,7 @@ class FifteenFourDevBoardNode(WpantundWpanNode, NetnsController):
         NOTE: this method uses linux `ip` command.
         """
         interface = self.thread_interface
-        cmd = f"ip -6 address del {address} /{prefix_len} dev {interface}"
+        cmd = f"ip -6 address del {address}/{prefix_len} dev {interface}"
         result = self.make_netns_call(cmd, 15)
 
         return result

--- a/silk/node/openthread_sniffer.py
+++ b/silk/node/openthread_sniffer.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 This module requires that the OpenThread spinel-cli tools are installed
 
@@ -24,24 +23,24 @@ This module requires that the OpenThread spinel-cli tools are installed
 
     $ sudo visudo
 
-        Option 1: Add /usr/local/bin to your secure path
-        Option 2: Create a symlink from a secure path location to the sniffer.py
-                  you found above
+    Option 1: Add /usr/local/bin to your secure path
+    Option 2: Create a symlink from a secure path location to the sniffer.py
+        you found above
 
 This module makes subprocess calls out to sniffer.py to generate packet
 captures.
 """
-from builtins import str
 import os
 import subprocess
 
-import silk.hw.hw_resource as hwr
 from silk.node.sniffer_base import SnifferNode
+import silk.hw.hw_resource as hwr
 
 sniffer_py_path = None
 
 
 class OpenThreadSniffer(SnifferNode):
+
     def __init__(self):
         super().__init__()
         self.sniffer_process = None
@@ -56,9 +55,9 @@ class OpenThreadSniffer(SnifferNode):
             sniffer_py_path = subprocess.check_output(["which", "sniffer.py"]).strip()
         except Exception as error:
             self.logger.debug("Error getting sniffer.py path: %s" % error)
-            sniffer_py_path = '/usr/local/bin/sniffer.py'
+            sniffer_py_path = "/usr/local/bin/sniffer.py"
 
-        self.device = hwr.global_instance().get_hw_module(self._hwModel)
+        self.device = hwr.global_instance().get_hw_module(self._hw_model)
 
     def set_up(self):
         pass
@@ -69,12 +68,15 @@ class OpenThreadSniffer(SnifferNode):
 
     def start(self, channel, output_path):
         self.channel = channel
-        sniffer_args = [sniffer_py_path, "-c", str(channel), "-n 1", "--crc", "-b 115200", "--no-reset",
-                        "-u", self.device.port()]
+        sniffer_args = [
+            sniffer_py_path, "-c",
+            str(channel), "-n 1", "--crc", "-b 115200", "--no-reset", "-u",
+            self.device.port()
+        ]
 
         self.output_path = os.path.join(output_path, "thread_channel_%s.pcap" % channel)
         self.outfile = open(self.output_path, "wb")
-        self.sniffer_process = subprocess.Popen(sniffer_args, bufsize=0, stdout = self.outfile)
+        self.sniffer_process = subprocess.Popen(sniffer_args, bufsize=0, stdout=self.outfile)
 
     def restart(self):
         if self.sniffer_process is not None:
@@ -82,8 +84,7 @@ class OpenThreadSniffer(SnifferNode):
 
         self.fragment_count += 1
         output_name = os.path.splitext(self.output_path)
-        self.outfile = open(output_name[0] + "_fragment_{0}"
-                            .format(self.fragment_count) + output_name[1], "wb")
+        self.outfile = open(output_name[0] + "_fragment_{0}".format(self.fragment_count) + output_name[1], "wb")
 
         sniffer_args = [sniffer_py_path, "-c", str(self.channel), "-u", self.device.port()]
         self.sniffer_process = subprocess.Popen(sniffer_args, bufsize=0, stdout=self.outfile)
@@ -103,5 +104,4 @@ class OpenThreadSniffer(SnifferNode):
 
 
 class NordicSniffer(OpenThreadSniffer):
-    _hwModel = "NordicSniffer"
-
+    _hw_model = "NordicSniffer"

--- a/silk/node/sniffer_base.py
+++ b/silk/node/sniffer_base.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import object
 import logging
 
 
 class SnifferNode(object):
+
     def __init__(self):
         self.logger = None
         self.device = None

--- a/silk/node/wpan_node.py
+++ b/silk/node/wpan_node.py
@@ -11,27 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-"""
-Base node profile for 6LowPAN networks (Thread, CIP)
+"""Base node profile for 6LowPAN networks (Thread, CIP).
 """
 
-from builtins import zip
-from builtins import object
 from . import base_node
 from .base_node import not_implemented
-
-import silk.tools.watchable as watchable
-
 import silk.postprocessing.wpan as mp_wpan
+import silk.tools.watchable as watchable
 
 
 class WpanCredentials(object):
+    """Class for storing WPAN credentials.
     """
-    Class for storing WPAN credentials
-    """
-    def __init__(self, network_name='wpan', psk='0', channel=0, 
-                 fabric_id='abdefabcdef', xpanid='000000000', panid=0):
+
+    def __init__(self, network_name="wpan", psk="0", channel=0, fabric_id="abdefabcdef", xpanid="000000000", panid=0):
         self.name = network_name
         self.psk = psk
         self.channel = channel
@@ -51,19 +44,19 @@ class WpanCredentials(object):
 
 
 class WpanNode(base_node.BaseNode):
+    """Define the WPAN base node interface.
     """
-    Define the WPAN base node interface
-    """
-    def __init__(self, name='WpanNode'):
+
+    def __init__(self, name="WpanNode"):
         super(WpanNode, self).__init__(name)
 
-        wpan_network_state_watchable = watchable.WatchableWithHistory(name = "WPAN network state", logger = self.logger)
+        wpan_network_state_watchable = watchable.WatchableWithHistory(name="WPAN network state", logger=self.logger)
         self.store_data(wpan_network_state_watchable, self.wpan_network_state_label)
-        wpan_network_version_watchable = watchable.WatchableWithHistory(name = "WPAN radio version", logger = self.logger)
+        wpan_network_version_watchable = watchable.WatchableWithHistory(name="WPAN radio version", logger=self.logger)
         self.store_data(wpan_network_version_watchable, self.wpan_version_label)
 
         for address_type in mp_wpan.WPAN_ADDRESS_TYPES:
-            address_watchable = watchable.WatchableWithHistory(name = address_type, logger = self.logger)
+            address_watchable = watchable.WatchableWithHistory(name=address_type, logger=self.logger)
             self.store_data(address_watchable, self.__wpan_address_label(address_type))
 
     def reboot_trigger_invoked(self):
@@ -74,25 +67,25 @@ class WpanNode(base_node.BaseNode):
 
     @property
     def wpan_network_state_label(self):
-        return 'wpan_network_state'
+        return "wpan_network_state"
 
     @property
     def wpan_network_state(self):
         return self.get_data(self.wpan_network_state_label)
-    
+
     def wpan_network_state_clear(self):
         return self.wpan_network_state.set(mp_wpan.NETWORK_STATE_NO_NETWORK)
 
     @property
     def wpan_version_label(self):
-        return 'wpan_version'
+        return "wpan_version"
 
     @property
     def wpan_version(self):
         return self.get_data(self.wpan_version_label)
 
     def __wpan_address_label(self, address_type):
-        return 'wpan_address(%s)' % address_type
+        return "wpan_address(%s)" % address_type
 
     def _wpan_address(self, address_type):
         return self.get_data(self.__wpan_address_label(address_type))
@@ -103,8 +96,7 @@ class WpanNode(base_node.BaseNode):
 
     @property
     def ip6_legacy_ula(self):
-        """
-        Legacy ULA Address (subnet 2).
+        """Legacy ULA Address (subnet 2).
 
         Used for alarming. This address starts with 0xFD and has the weave
         prefix.
@@ -117,8 +109,7 @@ class WpanNode(base_node.BaseNode):
 
     @property
     def ip6_thread_ula(self):
-        """
-        Thread ULA Address (subnet 6).
+        """Thread ULA Address (subnet 6).
 
         This address starts with 0xFD and has the weave prefix.
         """
@@ -130,12 +121,11 @@ class WpanNode(base_node.BaseNode):
 
     @property
     def wpan_mac_addr(self):
-        """
-        MAC Address (Device HW address) for WPAN device.
+        """MAC Address (Device HW address) for WPAN device.
 
-        Removes any ':' from string
+        Removes any ":" from string
         """
-        return self.get_data(self.wpan_mac_addr_label, default = '').replace(':','')
+        return self.get_data(self.wpan_mac_addr_label, default="").replace(":", "")
 
     @property
     def network_name_label(self):
@@ -151,7 +141,7 @@ class WpanNode(base_node.BaseNode):
 
     @property
     def panid(self):
-        return self.get_data(self.panid_label, 'hex-int', default=-1)
+        return self.get_data(self.panid_label, "hex-int", default=-1)
 
     @property
     def xpanid_label(self):
@@ -194,8 +184,8 @@ class WpanNode(base_node.BaseNode):
         return self.get_data(self.ip6_postfix_label)
 
     def ip6_postfix_process(self):
-        mac_addr = self.get_data(self.ip6_postfix_label).split(':')
-        postfix = ':'.join([i+j for i, j in zip(mac_addr[::2], mac_addr[1::2])])
+        mac_addr = self.get_data(self.ip6_postfix_label).split(":")
+        postfix = ":".join([i + j for i, j in zip(mac_addr[::2], mac_addr[1::2])])
         self.store_data(postfix[2:], self.ip6_postfix_label)
 
     @not_implemented
@@ -216,18 +206,18 @@ class WpanNode(base_node.BaseNode):
         appropriate for the device role.
         """
         pass
-    
+
     @not_implemented
     def provisional_join(self, network, role):
         """
-        Join a specified network without PSK
-        """
+    Join a specified network without PSK
+    """
 
     @not_implemented
     def complete_provisional_joining(self, network, role):
         """
-        Completely join a provisionally-joined network 
-        """
+    Completely join a provisionally-joined network 
+    """
 
     @not_implemented
     def leave(self):

--- a/silk/node/wpantund_base.py
+++ b/silk/node/wpantund_base.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import silk.hw.hw_resource
-from silk.node import wpan_node
 from silk.config import wpan_constants as wpan
+from silk.node import wpan_node
+import silk.hw.hw_resource
 
 
 def role_is_thread(role):
@@ -29,17 +29,15 @@ def role_is_thread(role):
 
 class WpantundWpanNode(wpan_node.WpanNode):
     """
-    This is the base class for controlling interactions with wpantund.  This
-    should provide a flexible overlay that can be ported to control Nordic,
-    SiLabs dev boards, and any other dev board connected to a Linux machine
-    with wpantund running in network name spaces and any other device that
-    runs wpantund.
+    This is the base class for controlling interactions with wpantund. This should provide a flexible overlay that
+    can be ported to control Nordic, SiLabs dev boards, and any other dev board connected to a Linux machine
+    with wpantund running in network name spaces and any other device that runs wpantund.
 
-    This base class contains all the necessary hooks for calling into wpanctl
-    to configure the NCP and query its state information.
+    This base class contains all the necessary hooks for calling into wpanctlto configure the NCP and query its
+    state information.
 
     Requirements for inheriting classes:
-    1) Must set the _hwModel attribute
+    1) Must set the _hw_model attribute
     2) Must provide a wpanctl method and wpanctl_async method
     3) Must provide a _get_addr method
     4) Should fully implement the base_node and wpan_node functionality
@@ -47,7 +45,7 @@ class WpantundWpanNode(wpan_node.WpanNode):
 
     See fifteen_four_dev_board.py for implementation examples of 2 and 3.
     """
-    _hwModel = None
+    _hw_model = None
     _ip6_lla_regex = "fe80[a-fA-F0-9:]+"
     _ip6_mla_regex = "[fF][dD][a-fA-F0-9:]+"
     _ip6_legacy_ula_regex = "[fF][dD][a-fA-F0-9:]+"
@@ -55,20 +53,17 @@ class WpantundWpanNode(wpan_node.WpanNode):
     _xpanid_regex = "0x[a-fA-F0-9]{16}"
 
     def wpanctl(self, command, *args, **kwargs):
-        """
-        Implemented by inheriting class.
+        """Implemented by inheriting class.
         """
         pass
 
     def wpanctl_async(self, command, *args, **kwargs):
-        """
-        Implemented by inheriting class.
+        """Implemented by inheriting class.
         """
         pass
 
     def free_device(self):
-        """
-        Free up hardware resources consumed by this class.
+        """Free up hardware resources consumed by this class.
         """
         silk.hw.hw_resource.global_instance().free_hw_module(self.device)
         self.device = None
@@ -87,31 +82,24 @@ class WpantundWpanNode(wpan_node.WpanNode):
 #################################
 #   base_node functionality
 #################################
+
     def set_up(self):
-        """
-        """
         pass
 
     def tear_down(self):
-        """
-        """
         pass
 
     def firmware_update(self, fw_file):
-        """
-        """
         pass
 
     def reset_thread_radio(self):
-        """
-        Perform an NCP soft reset.
+        """Perform an NCP soft reset.
         """
         self.wpanctl_async("reset", "reset", "Resetting NCP. . .", 5)
         self.make_system_call_async("reset", "sleep 4; echo done", "done", 20)
 
     def firmware_version(self):
-        """
-        Query the version of the Thread/ConnectIP stack running on the NCP.
+        """Query the version of the Thread/ConnectIP stack running on the NCP.
         """
 
         return self.getprop("NCPVersion")
@@ -121,18 +109,20 @@ class WpantundWpanNode(wpan_node.WpanNode):
 #################################
 
     def whitelist_node(self, node):
-        """Adds a given node (of type `Node`) to the whitelist of `self` and enables whitelisting on `self`"""
-
+        """Adds a given node (of type `Node`) to the whitelist of `self` and enables whitelisting on `self`.
+        """
         self.add(wpan.WPAN_MAC_WHITELIST_ENTRIES, node.get(wpan.WPAN_EXT_ADDRESS)[1:-1])
-        self.set(wpan.WPAN_MAC_WHITELIST_ENABLED, '1')
+        self.set(wpan.WPAN_MAC_WHITELIST_ENABLED, "1")
 
     def un_whitelist_node(self, node):
-        """Removes a given node (of node `Node) from the whitelist"""
+        """Removes a given node (of node `Node) from the whitelist.
+        """
         self.remove(wpan.WPAN_MAC_WHITELIST_ENTRIES, node.get(wpan.WPAN_EXT_ADDRESS)[1:-1])
 
 #################################
 #   wpan_node functionality
 #################################
+
     def form(self, network, role, xpanid=None, panid=None):
         """
         Form the PAN specified by the arguments.
@@ -163,8 +153,7 @@ class WpantundWpanNode(wpan_node.WpanNode):
         self._get_addr("form")
 
     def join(self, network, role):
-        """
-        Tell the NCP to join the PAN specified by the commissioning data.
+        """Tell the NCP to join the PAN specified by the commissioning data.
 
         The Network Key should always be set prior to a join attempt.
         """
@@ -180,9 +169,8 @@ class WpantundWpanNode(wpan_node.WpanNode):
         role = getattr(wpan, "ROLES")[role]
         self.store_data(role, self.role_label)
 
-        join_command = "join %s -T %s -c %s -x %s -p 0x%x" %\
-                       (network.name, role, network.channel,
-                        network.xpanid, network.panid)
+        join_command = "join %s -T %s -c %s -x %s -p 0x%x" % \
+            (network.name, role, network.channel, network.xpanid, network.panid)
 
         self.wpanctl_async("join", join_command, "Successfully Joined!", 60)
 
@@ -191,8 +179,7 @@ class WpantundWpanNode(wpan_node.WpanNode):
         self._get_addr("join")
 
     def provisional_join(self, network, role):
-        """
-        Perform an insecure join and then set the network key.
+        """Perform an insecure join and then set the network key.
         """
         self.store_data(network.fabric_id, "fabric-id")
 
@@ -201,13 +188,12 @@ class WpantundWpanNode(wpan_node.WpanNode):
         role = getattr(wpan, "ROLES")[role]
         self.store_data(role, self.role_label)
 
-        join_command = "join %s -T %s -c %s -x %s -p 0x%x" %\
-                       (network.name, role, network.channel,
-                        network.xpanid, network.panid)
+        join_command = "join %s -T %s -c %s -x %s -p 0x%x" % \
+            (network.name, role, network.channel, network.xpanid, network.panid)
 
         # Join to provisionally-joined state
-        self.wpanctl_async("join", join_command, 
-                           "Partial \(insecure\) join. Credentials needed. Update key to continue.", 30)
+        self.wpanctl_async("join", join_command,
+                           r"Partial \(insecure\) join. Credentials needed. Update key to continue.", 30)
 
         command = "setprop Network:Key --data %s" % network.psk
 
@@ -220,36 +206,32 @@ class WpantundWpanNode(wpan_node.WpanNode):
         self._get_addr("join")
 
     def __get_network_properties(self, action, network):
+        """Extract channel, PANID, XPANID, node type, and network key.
         """
-        Extract channel, PANID, XPANID, node type, and network key.
-        """
-        self.wpanctl_async(action, "getprop channel"   , " [0-9]{2}$"         , 20, self.channel_label)
-        self.wpanctl_async(action, "getprop panid"     , "0x[0-9a-fA-F]{4}$"  , 20, self.panid_label)
-        self.wpanctl_async(action, "getprop xpanid"    , "0x[a-fA-F0-9]{16}$" , 20, self.xpanid_label)
+        self.wpanctl_async(action, "getprop channel", " [0-9]{2}$", 20, self.channel_label)
+        self.wpanctl_async(action, "getprop panid", "0x[0-9a-fA-F]{4}$", 20, self.panid_label)
+        self.wpanctl_async(action, "getprop xpanid", "0x[a-fA-F0-9]{16}$", 20, self.xpanid_label)
 
         self.wpanctl_async(action, "get IPv6:LinkLocalAddress", self._ip6_lla_regex, 20, self.ip6_lla_label)
         self.wpanctl_async(action, "get IPv6:MeshLocalAddress", self._ip6_mla_regex, 20, self.ip6_mla_label)
 
-        self.wpanctl_async(action, "getprop Network:Key", "\[[0-9a-fA-F]{32}\]", 20, self.psk_label)
+        self.wpanctl_async(action, "getprop Network:Key", r"\[[0-9a-fA-F]{32}\]", 20, self.psk_label)
 
         self.wpanctl_async(action, "status", "AllowingJoin", 20)
 
     def leave(self):
-        """
-        Tell the NCP to leave its current PAN.
+        """Tell the NCP to leave its current PAN.
         """
         self.wpanctl_async("leave", "leave", "Leaving current WPAN. . .", 60)
         self.clear_state()
 
     def resume(self):
-        """
-        Tell the NCP to resume.
+        """Tell the NCP to resume.
         """
         self.wpanctl_async("resume", "resume", "Resuming saved WPAN. . .", 10)
 
     def permit_join(self, period=None):
-        """
-        Tell the NCP to allow joining for period seconds.
+        """Tell the NCP to allow joining for period seconds.
         """
         if not period:
             period = 240
@@ -258,30 +240,27 @@ class WpantundWpanNode(wpan_node.WpanNode):
 
     def permit_join_new(self, duration_sec=None, port=None, udp=True, tcp=True):
         if not udp and not tcp:  # incorrect use!
-            return ''
-        traffic_type = ''
+            return ""
+        traffic_type = ""
         if udp and not tcp:
-            traffic_type = ' --udp'
+            traffic_type = " --udp"
         if tcp and not udp:
-            traffic_type = ' --tcp'
+            traffic_type = " --tcp"
         if port is not None and duration_sec is None:
-            duration_sec = '240'
+            duration_sec = "240"
 
-        return self.wpanctl('permit-join', 'permit-join' +
-                            (' {}'.format(duration_sec) if duration_sec is not None else '') +
-                            (' {}'.format(port) if port is not None else '') +
-                            traffic_type, 5)
+        return self.wpanctl(
+            "permit-join", "permit-join" + (" {}".format(duration_sec) if duration_sec is not None else "") +
+            (" {}".format(port) if port is not None else "") + traffic_type, 5)
 
     def perform_active_scan(self, channel=None):
-        """
-        Tell the NCP to scan for other networks.
+        """Tell the NCP to scan for other networks.
         Return the list of other networks that have been seen.
         """
         self.wpanctl_async("scan", "scan", None, 20)
 
     def get_active_scan(self, channel=None):
-        """
-        Scan and Return list of other networks that have been seen
+        """Scan and Return list of other networks that have been seen.
         """
         if channel:
             output = self.wpanctl("scan", "scan -c {}".format(channel), 20)
@@ -298,65 +277,74 @@ class WpantundWpanNode(wpan_node.WpanNode):
         return output
 
     def get_discover_scan(self, channel=None, joiner_only=False, enable_filtering=False, panid_filter=None):
-        cmd = 'scan -d ' + (' -c {}'.format(channel) if channel  else '') + (' -j' if joiner_only else '')
-        cmd += (' -f' if enable_filtering else '') + (' -p {}'.format(panid_filter) if panid_filter else '')
+        cmd = "scan -d " + (" -c {}".format(channel) if channel else "") + (" -j" if joiner_only else "")
+        cmd += (" -f" if enable_filtering else "") + (" -p {}".format(panid_filter) if panid_filter else "")
         return self.wpanctl("scan", cmd, 20)
 
     def config_gateway1(self, prefix, default_route=False, priority=None):
-        return self.wpanctl('config-gateway', 'config-gateway ' + prefix +
-                            (' -d' if default_route else '') +
-                            (' -P {}'.format(priority) if priority is not None else ''), 20)
+        return self.wpanctl(
+            "config-gateway", "config-gateway " + prefix + (" -d" if default_route else "") +
+            (" -P {}".format(priority) if priority is not None else ""), 20)
 
-    def add_prefix(self, prefix, prefix_len=None, priority=None, stable=True, on_mesh=False, slaac=False, dhcp=False,
-                   configure=False, default_route=False, preferred=False):
-        return self.wpanctl('add-prefix', 'add-prefix ' + prefix +
-                            (' -l {}'.format(prefix_len) if prefix_len is not None else '') +
-                            (' -P {}'.format(priority) if priority is not None else '') +
-                            (' -s' if stable else '') +
-                            (' -f' if preferred else '') +
-                            (' -a' if slaac else '') +
-                            (' -d' if dhcp else '') +
-                            (' -c' if configure else '') +
-                            (' -r' if default_route else '') +
-                            (' -o' if on_mesh else ''), 20)
+    def add_prefix(self,
+                   prefix,
+                   prefix_len=None,
+                   priority=None,
+                   stable=True,
+                   on_mesh=False,
+                   slaac=False,
+                   dhcp=False,
+                   configure=False,
+                   default_route=False,
+                   preferred=False):
+        return self.wpanctl(
+            "add-prefix", "add-prefix " + prefix + (" -l {}".format(prefix_len) if prefix_len is not None else "") +
+            (" -P {}".format(priority) if priority is not None else "") + (" -s" if stable else "") +
+            (" -f" if preferred else "") + (" -a" if slaac else "") + (" -d" if dhcp else "") +
+            (" -c" if configure else "") + (" -r" if default_route else "") + (" -o" if on_mesh else ""), 20)
 
     def remove_prefix(self, prefix, prefix_len=None):
-        return self.wpanctl('remove-prefix', 'remove-prefix ' + prefix +
-                            (' -l {}'.format(prefix_len) if prefix_len is not None else ''), 20)
+        return self.wpanctl(
+            "remove-prefix",
+            "remove-prefix " + prefix + (" -l {}".format(prefix_len) if prefix_len is not None else ""), 20)
 
     def add_route_prefix(self, route_prefix, prefix_len=None, priority=None, stable=True):
-        """route priority [(>0 for high, 0 for medium, <0 for low)]"""
-        return self.wpanctl('add-route', 'add-route ' + route_prefix +
-                            (' -l {}'.format(prefix_len) if prefix_len is not None else '') +
-                            (' -p {}'.format(priority) if priority is not None else '') +
-                            ('' if stable else '-n'), 20)
+        """route priority [(>0 for high, 0 for medium, <0 for low)].
+        """
+        return self.wpanctl(
+            "add-route",
+            "add-route " + route_prefix + (" -l {}".format(prefix_len) if prefix_len is not None else "") +
+            (" -p {}".format(priority) if priority is not None else "") + ("" if stable else "-n"), 20)
 
     def remove_route(self, route_prefix, prefix_len=None, priority=None, stable=True):
-        """route priority [(>0 for high, 0 for medium, <0 for low)]"""
-        return self.wpanctl('remove-route', 'remove-route ' + route_prefix +
-                            (' -l {}'.format(prefix_len) if prefix_len is not None else '') +
-                            (' -p {}'.format(priority) if priority is not None else ''))
+        """route priority [(>0 for high, 0 for medium, <0 for low)].
+        """
+        return self.wpanctl(
+            "remove-route",
+            "remove-route " + route_prefix + (" -l {}".format(prefix_len) if prefix_len is not None else "") +
+            (" -p {}".format(priority) if priority is not None else ""))
 
 #################################
 #   Calls into wpanctl for commissioning process in commissioner-joiner model
 #################################
 
     def commissioner_start(self):
-        self.wpanctl_async('commissioner start', "commissioner start", "Commissioner started", 20)
+        self.wpanctl_async("commissioner start", "commissioner start", "Commissioner started", 20)
 
-    def commissioner_add_joiner(self, eui64, pskd, timeout='100'):
+    def commissioner_add_joiner(self, eui64, pskd, timeout="100"):
         cmd = "commissioner joiner-add {} {} {}".format(eui64, timeout, pskd)
-        return self.wpanctl('commissioner add-joiner', cmd, 20)
+        return self.wpanctl("commissioner add-joiner", cmd, 20)
 
     def joiner_join(self, pskd):
-        return self.wpanctl('joiner-join', 'joiner --join {}'.format(pskd), 60)
+        return self.wpanctl("joiner-join", "joiner --join {}".format(pskd), 60)
 
     def joiner_attach(self):
-        return self.wpanctl('joiner-attach', 'joiner --attach', 20)
+        return self.wpanctl("joiner-attach", "joiner --attach", 20)
 
 #################################
 #   Calls into wpanctl for querying commissioning data
 #################################
+
     def setprop(self, key, value, data=False):
         """
         Make a call into wpanctl setprop to set the desired parameter.
@@ -372,7 +360,7 @@ class WpantundWpanNode(wpan_node.WpanNode):
         Make a call into wpanctl getprop to query the desired parameter.
         """
         prop = self.wpanctl("getprop", "getprop %s" % property_name, 2)
-        return prop.split("=")[1].strip() if '=' in prop else prop
+        return prop.split("=")[1].strip() if "=" in prop else prop
 
     def get(self, prop_name, value_only=True):
         if value_only:
@@ -382,17 +370,17 @@ class WpantundWpanNode(wpan_node.WpanNode):
         return output.strip()
 
     def set(self, prop_name, value, binary_data=False):
-        return self._update_prop('set', prop_name, value, binary_data)
+        return self._update_prop("set", prop_name, value, binary_data)
 
     def add(self, prop_name, value, binary_data=False):
-        return self._update_prop('add', prop_name, value, binary_data)
+        return self._update_prop("add", prop_name, value, binary_data)
 
     def remove(self, prop_name, value, binary_data=False):
-        return self._update_prop('remove', prop_name, value, binary_data)
+        return self._update_prop("remove", prop_name, value, binary_data)
 
     def _update_prop(self, action, prop_name, value, binary_data):
-        return self.wpanctl(action, action + ' ' + prop_name + ' ' + ('-d ' if binary_data else '') +
-                            '-v ' + value, 2)  # use -v to handle values starting with `-`.
+        return self.wpanctl(action, action + " " + prop_name + " " + ("-d " if binary_data else "") + "-v " + value,
+                            2)  # use -v to handle values starting with `-`.
 
 
 #################################
@@ -418,12 +406,12 @@ class WpantundWpanNode(wpan_node.WpanNode):
 
         command += " %s -c %s -s %s -W 10" % (ipv6_target, num_pings, payload_size)
 
-        search_string = "(?P<%s>[\d]+) packets transmitted, (?P<%s>[\d]+) received" \
-                        % (self.ping6_sent_label, self.ping6_received_label)
+        search_string = r"(?P<%s>[\d]+) packets transmitted, (?P<%s>[\d]+) received" \
+            % (self.ping6_sent_label, self.ping6_received_label)
 
         fields = [self.ping6_sent_label, self.ping6_received_label]
 
-        self.make_netns_call_async(command, search_string, num_pings*2+1, field=fields)
+        self.make_netns_call_async(command, search_string, num_pings * 2 + 1, field=fields)
 
     def timed_ping6(self, ipv6_target, num_pings, payload_size=8, interface=None):
         """Perform ping6 to ipv6_target.
@@ -440,12 +428,9 @@ class WpantundWpanNode(wpan_node.WpanNode):
 
         command += " %s -c %s -s %s -W 2" % (ipv6_target, num_pings, payload_size)
 
-        search_string = "rtt min/avg/max/mdev = \d+\.\d+/(?P<%s>\d+\.\d+)/\d+\.\d+/\d+\.\d+ ms" \
-                        % (self.ping6_round_trip_time_label)
+        search_string = r"rtt min/avg/max/mdev = \d+\.\d+/(?P<%s>\d+\.\d+)/\d+\.\d+/\d+\.\d+ ms" \
+            % (self.ping6_round_trip_time_label)
 
         fields = [self.ping6_round_trip_time_label]
 
-        self.make_netns_call_async(command, search_string, num_pings*2+1, field=fields)
-
-
-
+        self.make_netns_call_async(command, search_string, num_pings * 2 + 1, field=fields)

--- a/silk/postprocessing/hwaddr.py
+++ b/silk/postprocessing/hwaddr.py
@@ -15,7 +15,7 @@
 
 def hwaddr_plain_add_colons(plain_hwaddr):
     eui = ""
-    for (i,c) in enumerate(plain_hwaddr):
+    for (i, c) in enumerate(plain_hwaddr):
 
         c = int(c, 16)
         if i == 1:
@@ -23,7 +23,7 @@ def hwaddr_plain_add_colons(plain_hwaddr):
 
         eui = eui + "%x" % c
         if (i + 1) % 2 == 0 and i != len(plain_hwaddr) - 1:
-            eui = eui + ':'
+            eui = eui + ":"
 
     eui = eui.upper()
     return eui.upper()
@@ -32,7 +32,7 @@ def hwaddr_plain_add_colons(plain_hwaddr):
 def hwaddr_from_iid(iid):
     hwaddr = None
 
-    hwaddr_plain = iid.replace(':','')
+    hwaddr_plain = iid.replace(":", "")
     hwaddr = hwaddr_plain_add_colons(hwaddr_plain)
 
     return hwaddr.upper()

--- a/silk/postprocessing/ip.py
+++ b/silk/postprocessing/ip.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import str
-import re
-import silk.postprocessing.util
 import ipaddress
+import re
 
 from silk.postprocessing import hwaddr as mp_hwaddr
+import silk.postprocessing.util
 
 # e.g fd26:644d:c77f:0002:1ab4:3000:002d:d2c0
 IPV6_REGEX_CHUNK = "%s{1,4}" % silk.postprocessing.util.REGEX_HEX
@@ -26,9 +25,7 @@ IPV6_REGEX = "(%s:?:){1,7}(%s)" % (IPV6_REGEX_CHUNK, IPV6_REGEX_CHUNK)
 IPV6_ALL_NODES_BROADCAST = "FF02:0000:0000:0000:0000:0000:0000:0001"
 IPV6_ALL_NODES_BROADCAST_SHORT = "FF02::1"
 
-IPV6_CROSS_IGNORE_DESTS = [
-    "FF02:0000:0000:0000:0000:0000:0000:0002"
-]
+IPV6_CROSS_IGNORE_DESTS = ["FF02:0000:0000:0000:0000:0000:0000:0002"]
 
 
 def ipv6_address_reformat(addr):
@@ -76,8 +73,7 @@ def lla_to_hwaddr(lla):
 
 
 def ipv6_assemble(prefix, subnet, iid):
-    """
-    Build an IPv6 address string
+    """Build an IPv6 address string.
 
     prefix must be a string containing a 48-bit hex value
     subnet must be a string containing a 16-bit hex value
@@ -87,34 +83,34 @@ def ipv6_assemble(prefix, subnet, iid):
 
     """
 
-    prefix = prefix.replace(':', '')
-    iid = iid.replace(':', '')
-    
+    prefix = prefix.replace(":", "")
+    iid = iid.replace(":", "")
+
     if len(prefix) != 12:
         raise ValueError("prefix must be length 12, %u given" % len(prefix))
-    
+
     if len(subnet) != 4:
         raise ValueError("subnet must be length 4, %u given" % len(subnet))
 
     if len(iid) != 16:
         #QK TODO
-        print('iid={}'.format(iid))
+        print("iid={}".format(iid))
         raise ValueError("iid must be length 16, %u given" % len(iid))
 
-    lower64 = int(iid, 16) | ( 1 << 57 )
+    lower64 = int(iid, 16) | (1 << 57)
 
     addr = [prefix, subnet, "%016x" % lower64]
     # clean up input strings
-    addr = [x.strip().replace('0x','') for x in addr]
-    addr = [x.replace(':','') for x in addr]
+    addr = [x.strip().replace("0x", "") for x in addr]
+    addr = [x.replace(":", "") for x in addr]
 
-    # Join and Insert ':'s
-    addr = ''.join(addr)
-    addr = ':'.join(re.findall(r"[0-9A-Fa-f]{4}", addr))
+    # Join and Insert ":"s
+    addr = "".join(addr)
+    addr = ":".join(re.findall(r"[0-9A-Fa-f]{4}", addr))
 
     return addr
 
 
 def assemble(fabric_id, subnet, iid):
-    prefix = 'fd' + fabric_id
+    prefix = "fd" + fabric_id
     return ipv6_assemble(prefix, subnet, iid)

--- a/silk/postprocessing/wpan.py
+++ b/silk/postprocessing/wpan.py
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""WPAN constants.
+"""
 
 import re
 
@@ -20,13 +22,10 @@ from silk.postprocessing import ip, util
 WPAN_FORMAT_RTOS = "rtos"
 WPAN_FORMAT_WPANTUND = "wpantund"
 
-WPAN_DIRECTION_SENT = '^'
-WPAN_DIRECTION_RCVD = 'v'
+WPAN_DIRECTION_SENT = "^"
+WPAN_DIRECTION_RCVD = "v"
 
-WPAN_DIRECTION_MAP = {
-    WPAN_DIRECTION_SENT: "Sent",
-    WPAN_DIRECTION_RCVD: "Rcvd"
-}
+WPAN_DIRECTION_MAP = {WPAN_DIRECTION_SENT: "Sent", WPAN_DIRECTION_RCVD: "Rcvd"}
 
 WPAN_PACKET_LENGTH_DELTA = 16
 
@@ -37,47 +36,49 @@ NETWORK_STATE_ATTACHED = 3
 NETWORK_STATE_ATTACHED_NO_PARENT = 4
 NETWORK_STATE_ATTACHING = 5
 
-WPAN_ADDRESS_LLA            = "LLA"
-WPAN_ADDRESS_MESH_LOCAL     = "Mesh-Local"
-WPAN_ADDRESS_WEAVE_LEGACY   = "Weave Legacy"
-WPAN_ADDRESS_WEAVE_THREAD   = "Weave Thread"
+WPAN_ADDRESS_LLA = "LLA"
+WPAN_ADDRESS_MESH_LOCAL = "Mesh-Local"
+WPAN_ADDRESS_WEAVE_LEGACY = "Weave Legacy"
+WPAN_ADDRESS_WEAVE_THREAD = "Weave Thread"
 
-WPAN_ADDRESS_WEAVE_SUBNET_MAP = {
-    2 : WPAN_ADDRESS_WEAVE_LEGACY,
-    6 : WPAN_ADDRESS_WEAVE_THREAD
-}
+WPAN_ADDRESS_WEAVE_SUBNET_MAP = {2: WPAN_ADDRESS_WEAVE_LEGACY, 6: WPAN_ADDRESS_WEAVE_THREAD}
 
 WPAN_ADDRESS_TYPES = [WPAN_ADDRESS_LLA, WPAN_ADDRESS_MESH_LOCAL, WPAN_ADDRESS_WEAVE_LEGACY, WPAN_ADDRESS_WEAVE_THREAD]
+"""
+Regular Expressions go here.
+"""
+__WPAN_PACKET_HEADER_RTOS_REGEX = re.compile(r"(?P<direction>.*),? (len|l): ?(?P<length>\d+),"
+                                             r" (f|m|management|typ): ?(\d+)(, st?:\d)?"
+                                             r"(, cksum:0x(?P<checksum>%s+))?" % util.REGEX_HEX)
+__WPAN_PACKET_HEADER_THCI_REGEX = re.compile(r"(?P<direction>.*) (pbuf_)?len: (?P<length>\d+),"
+                                             r" (ot_len: (\d+), )?cksum:0x(?P<checksum>%s+)" % util.REGEX_HEX)
 
-'''
-Regular Expressions go here
-'''
-__WPAN_PACKET_HEADER_RTOS_REGEX = re.compile("(?P<direction>.*),? (len|l): ?(?P<length>\d+), (f|m|management|typ): ?(\d+)(, st?:\d)?(, cksum:0x(?P<checksum>%s+))?" % util.REGEX_HEX)
-__WPAN_PACKET_HEADER_THCI_REGEX = re.compile("(?P<direction>.*) (pbuf_)?len: (?P<length>\d+), (ot_len: (\d+), )?cksum:0x(?P<checksum>%s+)" % util.REGEX_HEX)
+__WPAN_PACKET_HEADER_WPANTUND_REGEX = re.compile(r"\[(->)?NCP(->)?\] IPv6 len:(\d*)"
+                                                 r" type:\d+(\(cksum (0x%s+)\))? \[\w*\]" % util.REGEX_HEX)
+__WPAN_PACKET_FROM_TO_RTOS_REGEX = re.compile(r"\s?(FROM|TO):\s?(%s|%s)" %
+                                              (ip.IPV6_REGEX, ip.IPV6_ALL_NODES_BROADCAST_SHORT))
+__WPAN_PACKET_FROM_TO_WPANTUND_REGEX = re.compile(r"\s+(TO|FROM)\((LOCAL|REMOTE)\)"
+                                                  r":\[(%s)\](:\d*)?" % ip.IPV6_REGEX)
+__WPAN_PACKET_CHECKSUM_REGEX = re.compile(r"\s*(NEXTH:\d+, )?CKSUM:0X(%s+)" % util.REGEX_HEX)
 
-__WPAN_PACKET_HEADER_WPANTUND_REGEX = re.compile("\[(->)?NCP(->)?\] IPv6 len:(\d*) type:\d+(\(cksum (0x%s+)\))? \[\w*\]" % util.REGEX_HEX)
-__WPAN_PACKET_FROM_TO_RTOS_REGEX = re.compile("\s?(FROM|TO):\s?(%s|%s)" % (
-ip.IPV6_REGEX, ip.IPV6_ALL_NODES_BROADCAST_SHORT))
-__WPAN_PACKET_FROM_TO_WPANTUND_REGEX = re.compile("\s+(TO|FROM)\((LOCAL|REMOTE)\):\[(%s)\](:\d*)?" % ip.IPV6_REGEX)
-__WPAN_PACKET_CHECKSUM_REGEX = re.compile("\s*(NEXTH:\d+, )?CKSUM:0X(%s+)" % util.REGEX_HEX)
+__WPAN_PACKET_PAYLOAD_REGEX = re.compile(r"\s*↳\s*(%s+)" % util.REGEX_HEX)
 
-__WPAN_PACKET_PAYLOAD_REGEX = re.compile("\s*↳\s*(%s+)" % util.REGEX_HEX)
+WPAN_STATS_REGEX = re.compile(r"Stats ([A-Z_]*): ([\d]*)$")
 
-WPAN_STATS_REGEX = re.compile("Stats ([A-Z_]*): ([\d]*)$")
+__WPAN_VERSION_REGEX = re.compile(r"(\(wpan\))? (\w+) bin.mgmt.ver:(\d+),"
+                                  r" stack.ver:([\d\.]+), build.ver:(\d+) \((.+)\)")
 
-__WPAN_VERSION_REGEX = re.compile("(\(wpan\))? (\w+) bin.mgmt.ver:(\d+), stack.ver:([\d\.]+), build.ver:(\d+) \((.+)\)")
-
-__WPAN_NETWORK_STATE_REGEX = re.compile("CurrentNetwork id=([\w\-]*), ula=(%s), xPanId=(%s*), panId=(%s*), chan=(\d*), nodeType=\d, txPwr=(\-?\d*), status=(\d)?" % (
-    ip.IPV6_REGEX, util.REGEX_HEX, util.REGEX_HEX))
-__WPAN_NETWORK_STATE_NEW_REGEX = re.compile("CurrentNetwork id=([\w\-]*), xPanId=(%s*), panId=(%s*), chan=(\d*), nodeType=(\d*), txPwr=(\-?\d*), old status=(\d), new status=(\d)(, reason=\d)?" % (
-util.REGEX_HEX, util.REGEX_HEX))
-__WPAN_NETWORK_STATE_SHELL_REGEX = re.compile("Network status: '[\w_]+'\((\d+)\)")
+__WPAN_NETWORK_STATE_REGEX = re.compile(fr"CurrentNetwork id=([\w\-]*), ula=({ip.IPV6_REGEX}),"
+                                        fr" xPanId=({util.REGEX_HEX}*), panId=({util.REGEX_HEX}*),"
+                                        r" chan=(\d*), nodeType=\d, txPwr=(\-?\d*), status=(\d)?")
+__WPAN_NETWORK_STATE_NEW_REGEX = re.compile(fr"CurrentNetwork id=([\w\-]*), xPanId=({util.REGEX_HEX}*),"
+                                            fr" panId=({util.REGEX_HEX}*), chan=(\d*), nodeType=(\d*),"
+                                            r" txPwr=(\-?\d*), old status=(\d), new status=(\d)(, reason=\d)?")
+__WPAN_NETWORK_STATE_SHELL_REGEX = re.compile(r"Network status: '[\w_]+'\((\d+)\)")
 
 __WPAN_MODULES = ["WPAN", "wpantund", "APPL", "THCI", "OTHR"]
 
-__WPAN_NEW_ADDRESS_REGEX = re.compile("New (\w+) addr: (%s)([\s\(\)\w]+)?" % ip.IPV6_REGEX)
-
-
+__WPAN_NEW_ADDRESS_REGEX = re.compile(r"New (\w+) addr: (%s)([\s\(\)\w]+)?" % ip.IPV6_REGEX)
 """
 OpenThread Regex
 __OT_MODES: see openthread/src/cli/cli.cpp state options
@@ -85,10 +86,10 @@ __OT_VERSION_REGEX: OPENTHREAD/ga28078d; none; Jan 18 2017 04:08:34
 """
 __OT_MODES = ["offline", "disabled", "detached", "child", "router", "leader"]
 __OT_DEVICE_MODE_SHELL_REGEX = re.compile("(" + "|".join(__OT_MODES) + ")")
-__OT_DEVICE_MODE_NEW_SHELL_REGEX = re.compile("Mode -> (?P<new_mode>.*)")
-__OT_NETWORK_STATE_NEW_REGEX  = re.compile("\d+ \(.*\) -> \d+ \((?P<new_state>.*)\)")
-__OT_VERSION_REGEX = re.compile("(OPENTHREAD)/(.*); (.*); (.*)")
+__OT_DEVICE_MODE_NEW_SHELL_REGEX = re.compile(r"Mode -> (?P<new_mode>.*)")
+__OT_NETWORK_STATE_NEW_REGEX = re.compile(r"\d+ \(.*\) -> \d+ \((?P<new_state>.*)\)")
+__OT_VERSION_REGEX = re.compile(r"(OPENTHREAD)/(.*); (.*); (.*)")
 
-__OT_SEND_FAILURE_REGEX = re.compile("\[INFO\]\-+MAC\-+: Failed to send IPv6 UDP msg, len:(?P<length>\d+), chksum:(?P<checksum>%s+), to:(0x%s+), sec:(\w+), error:(?P<error>\w+), prio:(?P<priority>\w+)" % (
-util.REGEX_HEX, util.REGEX_HEX))
-
+__OT_SEND_FAILURE_REGEX = re.compile(r"\[INFO\]\-+MAC\-+: Failed to send IPv6 UDP msg, len:(?P<length>\d+),"
+                                     fr" chksum:(?P<checksum>{util.REGEX_HEX}+), to:(0x{util.REGEX_HEX}+),"
+                                     r" sec:(\w+), error:(?P<error>\w+), prio:(?P<priority>\w+)")

--- a/silk/shell/build_nrf52840.sh
+++ b/silk/shell/build_nrf52840.sh
@@ -29,7 +29,7 @@ if [[ $output == *"Already"* ]]; then
 
   echo "No code changes for Openthread........."
 
- else
+else
 
   echo "Started to build Openthread for nrf52840..........."
 

--- a/silk/tests/openthread/ot_test_add_ip6_address.py
+++ b/silk/tests/openthread/ot_test_add_ip6_address.py
@@ -12,21 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import range
-from silk.config import wpan_constants as wpan
-from silk.tools.wpan_util import verify, verify_within
-from silk.tools import wpan_util
-from silk.tools import wpan_table_parser
-
-import silk.node.fifteen_four_dev_board as ffdb
-from silk.node.wpan_node import WpanCredentials
-import silk.hw.hw_resource as hwr
-import silk.tests.testcase as testcase
-from silk.utils import process_cleanup
-
 import random
-import unittest
 import time
+import unittest
+
+from silk.config import wpan_constants as wpan
+from silk.node.wpan_node import WpanCredentials
+from silk.tools import wpan_table_parser
+from silk.tools import wpan_util
+from silk.tools.wpan_util import verify, verify_within
+from silk.utils import process_cleanup
+import silk.hw.hw_resource as hwr
+import silk.node.fifteen_four_dev_board as ffdb
+import silk.tests.testcase as testcase
 
 hwr.global_instance()
 
@@ -34,13 +32,14 @@ IP6_PREFIX_1 = "fd00:c0de::"
 IP6_PREFIX_2 = "fd00:deed::"
 IP6_PREFIX_3 = "fd00:beef::"
 
-IP6_ADDR_1  = IP6_PREFIX_1 + "1"
-IP6_ADDR_2  = IP6_PREFIX_2 + "2"
-IP6_ADDR_3  = IP6_PREFIX_3 + "3"
+IP6_ADDR_1 = IP6_PREFIX_1 + "1"
+IP6_ADDR_2 = IP6_PREFIX_2 + "2"
+IP6_ADDR_3 = IP6_PREFIX_3 + "3"
 
 
 class TestAddIPV6Address(testcase.TestCase):
-    # Test description: Adding/Removing IPv6 addresses on routers and SEDs on network interface.
+    # Test description: Adding/Removing IPv6 addresses on routers and SEDs
+    # on network interface.
     #
     # Test topology:
     #
@@ -55,17 +54,20 @@ class TestAddIPV6Address(testcase.TestCase):
     # - On `sed2` add `IP6_ADDR_3` with prefix `IP6_PREFIX_3`
     #
     # The test then covers the following:
-    # - Verify that the addresses are present in "IPv6:AllAddresses" wpantund property on the corresponding node.
-    # - Verify that all prefixes are present in network data with correct configuration flags (on all nodes).
-    # - Verify that `sed2`'s address is present in `r2` (its parent) "Thread:ChildTable:Addresses".
+    # - Verify that the addresses are present in "IPv6:AllAddresses" wpantund
+    #   property on the corresponding node.
+    # - Verify that all prefixes are present in network data with correct
+    #   configuration flags (on all nodes).
+    # - Verify that `sed2`'s address is present in `r2` (its parent)
+    #   "Thread:ChildTable:Addresses".
     # - Verify that addresses/prefixes are retained by wpantund over NCP reset.
-    # - Verify that when an IPv6 address is removed from network interface, its corresponding prefix
-    #   is also removed from all nodes.
+    # - Verify that when an IPv6 address is removed from network interface, its
+    #   corresponding prefix is also removed from all nodes.
 
     poll_interval = 1500
 
     @classmethod
-    def hardwareSelect(cls):
+    def hardware_select(cls):
         cls.r1 = ffdb.ThreadDevBoard()
         cls.r2 = ffdb.ThreadDevBoard()
         cls.fed1 = ffdb.ThreadDevBoard()
@@ -79,7 +81,7 @@ class TestAddIPV6Address(testcase.TestCase):
         # Check and clean up wpantund process if any left over
         process_cleanup.ps_cleanup()
 
-        cls.hardwareSelect()
+        cls.hardware_select()
 
         for device in cls.all_nodes:
 
@@ -88,12 +90,10 @@ class TestAddIPV6Address(testcase.TestCase):
 
             device.set_up()
 
-        cls.network_data = WpanCredentials(
-            network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
-            psk="00112233445566778899aabbccdd{0:04x}".
-                format(random.randint(0, 0xffff)),
-            channel=random.randint(11, 25),
-            fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
+        cls.network_data = WpanCredentials(network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
+                                           psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
+                                           channel=random.randint(11, 25),
+                                           fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
 
         cls.thread_sniffer_init(cls.network_data.channel)
 
@@ -112,7 +112,8 @@ class TestAddIPV6Address(testcase.TestCase):
         pass
 
     def check_addresses_and_prefixes(self):
-        # Verify that the addresses are present in "IPv6:AllAddresses" wpantund property on the corresponding node.
+        # Verify that the addresses are present in "IPv6:AllAddresses" wpantund
+        # property on the corresponding node.
         verify(self.r2.find_ip6_address_with_prefix(IP6_PREFIX_1) == IP6_ADDR_1)
         verify(self.fed1.find_ip6_address_with_prefix(IP6_PREFIX_2) == IP6_ADDR_2)
         verify(self.sed2.find_ip6_address_with_prefix(IP6_PREFIX_3) == IP6_ADDR_3)
@@ -122,8 +123,9 @@ class TestAddIPV6Address(testcase.TestCase):
             print(node)
             print(node_on_mesh_prefixes)
 
-        print('#'*30)
-        # Verify that all prefixes are present in network data on all nodes (with correct flags).
+        print("#" * 30)
+        # Verify that all prefixes are present in network data on all
+        # nodes (with correct flags).
         for prefix in [IP6_PREFIX_1, IP6_PREFIX_2, IP6_PREFIX_3]:
             for node in self.all_nodes:
                 node_on_mesh_prefixes = node.get(wpan.WPAN_THREAD_ON_MESH_PREFIXES)
@@ -132,7 +134,7 @@ class TestAddIPV6Address(testcase.TestCase):
                 print(prefixes)
                 for p in prefixes:
                     if p.prefix == prefix:
-                        verify(p.prefix_len == '64')
+                        verify(p.prefix_len == "64")
                         verify(p.is_stable())
                         verify(p.is_on_mesh() == True)
                         verify(p.is_preferred() == True)
@@ -143,11 +145,13 @@ class TestAddIPV6Address(testcase.TestCase):
                         verify(p.priority == "med")
                         break
                 else:  # `for` loop finished without finding the prefix.
-                    raise wpan_util.VerifyError('Did not find prefix {} on node {}'.format(prefix, node))
+                    raise wpan_util.VerifyError("Did not find prefix {} on node {}".format(prefix, node))
 
-        # Verify that IPv6 address of `sed2` is present on `r2` (its parent) "Thread:ChildTable:Addresses".
+        # Verify that IPv6 address of `sed2` is present on `r2` (its parent)
+        # "Thread:ChildTable:Addresses".
         addr_str = self.r2.get(wpan.WPAN_THREAD_CHILD_TABLE_ADDRESSES)
-        # search for index on address in the `addr_str` and ensure it is non-negative.
+        # search for index on address in the `addr_str` and ensure it is
+        # non-negative.
         verify(addr_str.find(IP6_ADDR_3) >= 0)
 
     @testcase.test_method_decorator
@@ -165,14 +169,13 @@ class TestAddIPV6Address(testcase.TestCase):
         self.r1.permit_join(3600)
         self.wait_for_completion(self.device_list)
 
-        # self.logger.info(self.former.wpanctl("manual-status-check", "status", 2))
         self.logger.info(self.r1.ip6_lla)
         self.logger.info(self.r1.ip6_thread_ula)
 
         self.network_data.xpanid = self.r1.xpanid
         self.network_data.panid = self.r1.panid
 
-        self.r2.join(self.network_data, 'router')
+        self.r2.join(self.network_data, "router")
         self.wait_for_completion(self.device_list)
 
         self.fed1.join(self.network_data, "end-node")
@@ -183,15 +186,15 @@ class TestAddIPV6Address(testcase.TestCase):
         self.sed2.set_sleep_poll_interval(self.poll_interval)
 
         for _ in range(18):
-            node_type = self.r2.wpanctl('get', 'get '+wpan.WPAN_NODE_TYPE, 2).split('=')[1].strip()[1:-1]
-            print(node_type == 'router')
+            node_type = self.r2.wpanctl("get", "get " + wpan.WPAN_NODE_TYPE, 2).split("=")[1].strip()[1:-1]
+            print(node_type == "router")
 
-            if node_type == 'router':
-                print('Matched!!!!!!!!!!!!!')
+            if node_type == "router":
+                print("Matched!!!!!!!!!!!!!")
                 break
             time.sleep(10)
         else:
-            self.assertFalse(True, 'Router cannot get into router role after 180 seconds timeout')
+            self.assertFalse(True, "Router cannot get into router role after 180 seconds timeout")
 
     @testcase.test_method_decorator
     def test02_Verify_Add_IPV6(self):
@@ -223,7 +226,7 @@ class TestAddIPV6Address(testcase.TestCase):
 
         def check_address_prefix_removed():
             # Verify that address is removed from r2
-            verify(self.r2.find_ip6_address_with_prefix(IP6_PREFIX_1) == '')
+            verify(self.r2.find_ip6_address_with_prefix(IP6_PREFIX_1) == "")
             # Verify that the related prefix is also removed on all nodes
             for node in self.all_nodes:
                 prefixes = wpan_table_parser.parse_on_mesh_prefix_result(node.get(wpan.WPAN_THREAD_ON_MESH_PREFIXES))

--- a/silk/tests/openthread/ot_test_child_mode_change.py
+++ b/silk/tests/openthread/ot_test_child_mode_change.py
@@ -12,33 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import str
-from silk.config import wpan_constants as wpan
-import silk.node.fifteen_four_dev_board as ffdb
-from silk.node.wpan_node import WpanCredentials
-from silk.tools import wpan_table_parser
-import silk.hw.hw_resource as hwr
-import silk.tests.testcase as testcase
-from silk.tools.wpan_util import verify, verify_within, VerifyError
-from silk.utils import process_cleanup
 import random
 import unittest
 
+from silk.config import wpan_constants as wpan
+from silk.node.wpan_node import WpanCredentials
+from silk.tools import wpan_table_parser
+from silk.tools.wpan_util import verify, verify_within, VerifyError
+from silk.utils import process_cleanup
+import silk.hw.hw_resource as hwr
+import silk.node.fifteen_four_dev_board as ffdb
+import silk.tests.testcase as testcase
 
 hwr.global_instance()
 
 WAIT_INTERVAL = 10
 # Thread Mode for end-device and sleepy end-device
-DEVICE_MODE_SLEEPY_END_DEVICE = wpan.THREAD_MODE_FLAG_FULL_NETWORK_DATA | wpan.THREAD_MODE_FLAG_SECURE_DATA_REQUEST
-DEVICE_MODE_END_DEVICE = wpan.THREAD_MODE_FLAG_FULL_NETWORK_DATA | wpan.THREAD_MODE_FLAG_FULL_THREAD_DEV \
-                         | wpan.THREAD_MODE_FLAG_SECURE_DATA_REQUEST | wpan.THREAD_MODE_FLAG_RX_ON_WHEN_IDLE
+DEVICE_MODE_SLEEPY_END_DEVICE = wpan.THREAD_MODE_FLAG_FULL_NETWORK_DATA \
+    | wpan.THREAD_MODE_FLAG_SECURE_DATA_REQUEST
+DEVICE_MODE_END_DEVICE = wpan.THREAD_MODE_FLAG_FULL_NETWORK_DATA \
+    | wpan.THREAD_MODE_FLAG_FULL_THREAD_DEV \
+    | wpan.THREAD_MODE_FLAG_SECURE_DATA_REQUEST \
+    | wpan.THREAD_MODE_FLAG_RX_ON_WHEN_IDLE
 
 
 class TestChildModeChange(testcase.TestCase):
     poll_interval = 8000
 
     @classmethod
-    def hardwareSelect(cls):
+    def hardware_select(cls):
         cls.parent = ffdb.ThreadDevBoard()
         cls.child1 = ffdb.ThreadDevBoard()
         cls.child2 = ffdb.ThreadDevBoard()
@@ -51,7 +53,7 @@ class TestChildModeChange(testcase.TestCase):
         # Check and clean up wpantund process if any left over
         process_cleanup.ps_cleanup()
 
-        cls.hardwareSelect()
+        cls.hardware_select()
 
         cls.add_test_device(cls.parent)
         cls.add_test_device(cls.child1)
@@ -61,11 +63,10 @@ class TestChildModeChange(testcase.TestCase):
             device.set_logger(cls.logger)
             device.set_up()
 
-        cls.network_data = WpanCredentials(
-            network_name = "SILK-{0:04X}".format(random.randint(0, 0xffff)),
-            psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
-            channel = random.randint(11, 25),
-            fabric_id = "{0:06x}dead".format(random.randint(0, 0xffffff)))
+        cls.network_data = WpanCredentials(network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
+                                           psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
+                                           channel=random.randint(11, 25),
+                                           fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
 
         cls.thread_sniffer_init(cls.network_data.channel)
 
@@ -85,10 +86,12 @@ class TestChildModeChange(testcase.TestCase):
 
     def verify_child_table(self, parent, children):
         """
-        This function verifies that child table on `parent` node contains all the entries in `children` list and the child
-        table entry's mode value matches the children Thread mode.
-        """
-        child_table = wpan_table_parser.parse_child_table_result(parent.wpanctl("get", "get "+wpan.WPAN_THREAD_CHILD_TABLE, 2))
+    This function verifies that child table on `parent` node contains all the
+    entries in `children` list and the child table entry's mode value matches
+    the children Thread mode.
+    """
+        child_table = wpan_table_parser.parse_child_table_result(
+            parent.wpanctl("get", "get " + wpan.WPAN_THREAD_CHILD_TABLE, 2))
         print(child_table)
 
         verify(len(child_table) == len(children))
@@ -98,21 +101,26 @@ class TestChildModeChange(testcase.TestCase):
                 if entry.ext_address == ext_addr:
                     break
             else:
-                raise VerifyError('Failed to find a child entry for extended address {} in table'.format(ext_addr))
+                raise VerifyError("Failed to find a child entry for extended address" " {} in table".format(ext_addr))
 
-            verify(int(entry.rloc16, 16) == int(child.get(wpan.WPAN_THREAD_RLOC16), 16))
+            verify(int(entry.rloc16, 16) \
+                == int(child.get(wpan.WPAN_THREAD_RLOC16), 16))
             mode = int(child.get(wpan.WPAN_THREAD_DEVICE_MODE), 0)
-            verify(entry.is_rx_on_when_idle() == (mode & wpan.THREAD_MODE_FLAG_RX_ON_WHEN_IDLE != 0))
-            verify(entry.is_ftd() == (mode & wpan.THREAD_MODE_FLAG_FULL_THREAD_DEV != 0))
-            verify(entry.is_full_net_data() == (mode & wpan.THREAD_MODE_FLAG_FULL_NETWORK_DATA != 0))
-            verify(entry.is_sec_data_req() == (mode & wpan.THREAD_MODE_FLAG_SECURE_DATA_REQUEST != 0))
+            verify(entry.is_rx_on_when_idle() \
+                == (mode & wpan.THREAD_MODE_FLAG_RX_ON_WHEN_IDLE != 0))
+            verify(entry.is_ftd() \
+                == (mode & wpan.THREAD_MODE_FLAG_FULL_THREAD_DEV != 0))
+            verify(entry.is_full_net_data() \
+                == (mode & wpan.THREAD_MODE_FLAG_FULL_NETWORK_DATA != 0))
+            verify(entry.is_sec_data_req() \
+                == (mode & wpan.THREAD_MODE_FLAG_SECURE_DATA_REQUEST != 0))
 
     def check_child_table(self):
         self.verify_child_table(self.parent, self.children)
 
     @testcase.test_method_decorator
     def test01_Pairing(self):
-        self.parent.form(self.network_data, 'router')
+        self.parent.form(self.network_data, "router")
         self.parent.permit_join(120)
         self.wait_for_completion(self.device_list)
 
@@ -133,13 +141,15 @@ class TestChildModeChange(testcase.TestCase):
     @testcase.test_method_decorator
     def test02_Verify_Child_Mode(self):
         # Disable child supervision on all devices
-        self.parent.set(wpan.WPAN_CHILD_SUPERVISION_INTERVAL, '0')
-        self.child1.set(wpan.WPAN_CHILD_SUPERVISION_CHECK_TIMEOUT, '0')
-        self.child2.set(wpan.WPAN_CHILD_SUPERVISION_CHECK_TIMEOUT, '0')
+        self.parent.set(wpan.WPAN_CHILD_SUPERVISION_INTERVAL, "0")
+        self.child1.set(wpan.WPAN_CHILD_SUPERVISION_CHECK_TIMEOUT, "0")
+        self.child2.set(wpan.WPAN_CHILD_SUPERVISION_CHECK_TIMEOUT, "0")
 
         # Verify Thread Device Mode on both children
-        verify(int(self.child1.get(wpan.WPAN_THREAD_DEVICE_MODE), 0) == DEVICE_MODE_END_DEVICE)
-        verify(int(self.child2.get(wpan.WPAN_THREAD_DEVICE_MODE), 0) == DEVICE_MODE_SLEEPY_END_DEVICE)
+        verify(int(self.child1.get(wpan.WPAN_THREAD_DEVICE_MODE), 0) \
+            == DEVICE_MODE_END_DEVICE)
+        verify(int(self.child2.get(wpan.WPAN_THREAD_DEVICE_MODE), 0) \
+            == DEVICE_MODE_SLEEPY_END_DEVICE)
 
         verify_within(self.check_child_table, WAIT_INTERVAL)
 
@@ -157,10 +167,12 @@ class TestChildModeChange(testcase.TestCase):
 
         # Change mode on both children (make child1 sleepy, and child2 non-sleepy)
         self.child1.set(wpan.WPAN_THREAD_DEVICE_MODE, str(DEVICE_MODE_SLEEPY_END_DEVICE))
-        verify(int(self.child1.get(wpan.WPAN_THREAD_DEVICE_MODE), 0) == DEVICE_MODE_SLEEPY_END_DEVICE)
+        verify(int(self.child1.get(wpan.WPAN_THREAD_DEVICE_MODE), 0) \
+            == DEVICE_MODE_SLEEPY_END_DEVICE)
 
         self.child2.set(wpan.WPAN_THREAD_DEVICE_MODE, str(DEVICE_MODE_END_DEVICE))
-        verify(int(self.child2.get(wpan.WPAN_THREAD_DEVICE_MODE), 0) == DEVICE_MODE_END_DEVICE)
+        verify(int(self.child2.get(wpan.WPAN_THREAD_DEVICE_MODE), 0) \
+            == DEVICE_MODE_END_DEVICE)
 
         # Verify that the child table on parent is also updated
         verify_within(self.check_child_table, WAIT_INTERVAL)

--- a/silk/tests/openthread/ot_test_child_supervision.py
+++ b/silk/tests/openthread/ot_test_child_supervision.py
@@ -12,22 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import str
-from builtins import range
+import os
+import random
+import subprocess
+import time
+import unittest
+
 from silk.config import wpan_constants as wpan
-import silk.node.fifteen_four_dev_board as ffdb
 from silk.node.wpan_node import WpanCredentials
 from silk.tools import wpan_table_parser
-import silk.hw.hw_resource as hwr
-import silk.tests.testcase as testcase
 from silk.tools.wpan_util import verify, verify_within
 from silk.utils import process_cleanup
-
-import random
-import unittest
-import time
-import os
-import subprocess
+import silk.hw.hw_resource as hwr
+import silk.node.fifteen_four_dev_board as ffdb
+import silk.tests.testcase as testcase
 
 CHILD_TIMEOUT = 6
 CHILD_SUPERVISION_CHECK_TIMEOUT = 12
@@ -40,7 +38,7 @@ class TestChildSupervision(testcase.TestCase):
     poll_interval = 500
 
     @classmethod
-    def hardwareSelect(cls):
+    def hardware_select(cls):
         cls.router = ffdb.ThreadDevBoard()
         cls.sed = ffdb.ThreadDevBoard()
 
@@ -50,7 +48,7 @@ class TestChildSupervision(testcase.TestCase):
         # Check and clean up wpantund process if any left over
         process_cleanup.ps_cleanup()
 
-        cls.hardwareSelect()
+        cls.hardware_select()
 
         cls.router.set_logger(cls.logger)
         cls.sed.set_logger(cls.logger)
@@ -61,12 +59,10 @@ class TestChildSupervision(testcase.TestCase):
         cls.router.set_up()
         cls.sed.set_up()
 
-        cls.network_data = WpanCredentials(
-            network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
-            psk="00112233445566778899aabbccdd{0:04x}".
-                format(random.randint(0, 0xffff)),
-            channel=random.randint(11, 25),
-            fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
+        cls.network_data = WpanCredentials(network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
+                                           psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
+                                           channel=random.randint(11, 25),
+                                           fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
 
         cls.thread_sniffer_init(cls.network_data.channel)
 
@@ -85,11 +81,11 @@ class TestChildSupervision(testcase.TestCase):
         pass
 
     def find_string_in_log_file(self):
-        filename = os.path.join(self.current_output_directory, 'silk.log')
-        cmd = 'grep ' + '"' + self.child_supervision_msg + '" ' + filename
+        filename = os.path.join(self.current_output_directory, "silk.log")
+        cmd = "grep " + "\"" + self.child_supervision_msg + "\" " + filename
         ret = subprocess.check_output(cmd, shell=True)
         self.logger.info(ret)
-        return verify(self.child_supervision_msg in ret.decode('utf-8'))
+        return verify(self.child_supervision_msg in ret.decode("utf-8"))
 
     @testcase.test_method_decorator
     def test01_Pairing(self):
@@ -97,7 +93,6 @@ class TestChildSupervision(testcase.TestCase):
         self.router.permit_join(3600)
         self.wait_for_completion(self.device_list)
 
-        # self.logger.info(self.former.wpanctl("manual-status-check", "status", 2))
         self.logger.info(self.router.ip6_lla)
         self.logger.info(self.router.ip6_thread_ula)
 
@@ -126,13 +121,13 @@ class TestChildSupervision(testcase.TestCase):
             print(ret)
 
             ret = self.sed.wpanctl("get", "get NCP:ExtendedAddress", 2)
-            print('Extended Address:{}'.format(ret))
+            print("Extended Address:{}".format(ret))
 
             ret = self.sed.wpanctl("get", "get NCP:HardwareAddress", 2)
-            print('SED Hardware Address:{}'.format(ret))
+            print("SED Hardware Address:{}".format(ret))
 
             ret = self.sed.wpanctl("get", "get NCP:MACAddress", 2)
-            print('SED MAC Address:{}'.format(ret))
+            print("SED MAC Address:{}".format(ret))
 
             time.sleep(5)
 
@@ -152,59 +147,60 @@ class TestChildSupervision(testcase.TestCase):
         print(timeout)
         self.assertEqual(int(timeout), CHILD_TIMEOUT)
 
-        self.sed.setprop(wpan.WPAN_CHILD_SUPERVISION_CHECK_TIMEOUT, '0')
+        self.sed.setprop(wpan.WPAN_CHILD_SUPERVISION_CHECK_TIMEOUT, "0")
         child_supervision_timeout = self.sed.getprop(wpan.WPAN_CHILD_SUPERVISION_CHECK_TIMEOUT)
         print(child_supervision_timeout)
         self.assertEqual(int(child_supervision_timeout, 16), 0)
 
-        self.router.setprop(wpan.WPAN_CHILD_SUPERVISION_INTERVAL, '0')
+        self.router.setprop(wpan.WPAN_CHILD_SUPERVISION_INTERVAL, "0")
         child_supervision_interval = self.router.getprop(wpan.WPAN_CHILD_SUPERVISION_INTERVAL)
         print(child_supervision_interval)
         self.assertEqual(int(child_supervision_interval, 16), 0)
 
     @testcase.test_method_decorator
     def test05_verify_childTable(self):
-        childTable = self.router.wpanctl("get", "get Thread:ChildTable", 2)
-        childTable = wpan_table_parser.parse_child_table_result(childTable)
-        sed_ext_address = self.sed.wpanctl("get", "get NCP:ExtendedAddress", 2).split('=')[-1].strip()[1:-1]
+        child_table = self.router.wpanctl("get", "get Thread:ChildTable", 2)
+        child_table = wpan_table_parser.parse_child_table_result(child_table)
+        sed_ext_address = self.sed.wpanctl("get", "get NCP:ExtendedAddress", 2).split("=")[-1].strip()[1:-1]
 
-        for e in childTable:
+        for e in child_table:
             if e.ext_address == sed_ext_address:
                 break
         else:
-            msg = 'Failed to find a child entry for extended address {} in table'.format(sed_ext_address)
+            msg = ("Failed to find a child entry for extended address" " {} in table".format(sed_ext_address))
             print(msg)
 
-        self.assertEqual(int(e.rloc16, 16), int(self.sed.wpanctl("get", "get " +
-                                                                 wpan.WPAN_THREAD_RLOC16, 2).split('=')[-1].strip(), 16))
+        self.assertEqual(int(e.rloc16, 16),
+                         int(self.sed.wpanctl("get", "get " + wpan.WPAN_THREAD_RLOC16, 2).split("=")[-1].strip(), 16))
         self.assertEqual(int(e.timeout, 0), CHILD_TIMEOUT)
         self.assertEqual(e.is_rx_on_when_idle(), False)
         self.assertEqual(e.is_ftd(), False)
 
     @testcase.test_method_decorator
     def test06_enable_whitelist(self):
-        self.router.setprop(wpan.WPAN_MAC_WHITELIST_ENABLED, '1')
+        self.router.setprop(wpan.WPAN_MAC_WHITELIST_ENABLED, "1")
 
         print(self.router.getprop(wpan.WPAN_MAC_WHITELIST_ENABLED))
 
-        self.assertEqual(self.router.getprop(wpan.WPAN_MAC_WHITELIST_ENABLED), 'true')
+        self.assertEqual(self.router.getprop(wpan.WPAN_MAC_WHITELIST_ENABLED), "true")
 
-        time.sleep(CHILD_TIMEOUT+3)
+        time.sleep(CHILD_TIMEOUT + 3)
 
-        childTable = self.router.wpanctl("get", "get Thread:ChildTable", 2)
-        print('Child Table:')
-        print(childTable)
-        childTable = wpan_table_parser.parse_child_table_result(childTable)
-        sed_ext_address = self.sed.wpanctl("get", "get NCP:ExtendedAddress", 2).split('=')[-1].strip()[1:-1]
+        child_table = self.router.wpanctl("get", "get Thread:ChildTable", 2)
+        print("Child Table:")
+        print(child_table)
+        child_table = wpan_table_parser.parse_child_table_result(child_table)
+        sed_ext_address = self.sed.wpanctl("get", "get NCP:ExtendedAddress", 2).split("=")[-1].strip()[1:-1]
 
-        print(childTable)
+        print(child_table)
 
-        for e in childTable:
-            self.assertNotEqual(e.ext_address, sed_ext_address, 'SED MAC {} still still in Router ChildTable'.format(e.ext_address))
+        for e in child_table:
+            self.assertNotEqual(e.ext_address, sed_ext_address,
+                                "SED MAC {} still still in Router ChildTable".format(e.ext_address))
 
-        # verify the sed is still associated since data polls are acked by radio driver) and
-        # supervision check is disabled on the child
-        self.assertTrue(wpan_table_parser.is_associated(self.sed), 'SED is not associated !!!')
+        # verify the sed is still associated since data polls are acked by radio
+        # driver and supervision check is disabled on the child
+        self.assertTrue(wpan_table_parser.is_associated(self.sed), "SED is not associated !!!")
 
     @testcase.test_method_decorator
     def test07_enable_supervision_on_child(self):
@@ -212,24 +208,25 @@ class TestChildSupervision(testcase.TestCase):
         # become detached after the check timeout
 
         self.sed.setprop(wpan.WPAN_CHILD_SUPERVISION_CHECK_TIMEOUT, str(CHILD_SUPERVISION_CHECK_TIMEOUT))
-        self.assertEqual(int(self.sed.getprop(wpan.WPAN_CHILD_SUPERVISION_CHECK_TIMEOUT), 16), int(CHILD_SUPERVISION_CHECK_TIMEOUT))
+        self.assertEqual(int(self.sed.getprop(wpan.WPAN_CHILD_SUPERVISION_CHECK_TIMEOUT), 16),
+                         int(CHILD_SUPERVISION_CHECK_TIMEOUT))
 
-        time.sleep(CHILD_SUPERVISION_CHECK_TIMEOUT*3+1)
+        time.sleep(CHILD_SUPERVISION_CHECK_TIMEOUT * 3 + 1)
 
-        self.assertTrue(wpan_table_parser.check_child_is_detached(self.sed), 'SED is still associated!!!')
+        self.assertTrue(wpan_table_parser.check_child_is_detached(self.sed), "SED is still associated!!!")
 
     @testcase.test_method_decorator
     def test08_enable_supervision_on_parent(self):
         # Enable child supervision on parent and disable white-listing
 
         self.router.setprop(wpan.WPAN_CHILD_SUPERVISION_INTERVAL, str(PARENT_SUPERVISION_INTERVAL))
-        self.router.setprop(wpan.WPAN_MAC_WHITELIST_ENABLED, '0')
+        self.router.setprop(wpan.WPAN_MAC_WHITELIST_ENABLED, "0")
 
         # Wait for the child to attach back
 
-        time.sleep(CHILD_SUPERVISION_CHECK_TIMEOUT*2)
+        time.sleep(CHILD_SUPERVISION_CHECK_TIMEOUT * 2)
 
-        self.assertTrue(wpan_table_parser.is_associated(self.sed), 'SED is still not associated!!!')
+        self.assertTrue(wpan_table_parser.is_associated(self.sed), "SED is still not associated!!!")
 
         # MAC counters are used to verify the child supervision behavior.
 
@@ -244,23 +241,23 @@ class TestChildSupervision(testcase.TestCase):
         print(parent_unicast_tx_count)
         print(self.router.getprop("NCP:Counter:TX_PKT_UNICAST"))
 
-        self.assertGreaterEqual(int(self.router.getprop("NCP:Counter:TX_PKT_UNICAST"), 0), parent_unicast_tx_count+1)
+        self.assertGreaterEqual(int(self.router.getprop("NCP:Counter:TX_PKT_UNICAST"), 0), parent_unicast_tx_count + 1)
 
         # Disable child supervision on parent
-        self.router.setprop(wpan.WPAN_CHILD_SUPERVISION_INTERVAL, '0')
+        self.router.setprop(wpan.WPAN_CHILD_SUPERVISION_INTERVAL, "0")
 
-        time.sleep(CHILD_SUPERVISION_CHECK_TIMEOUT*3)
+        time.sleep(CHILD_SUPERVISION_CHECK_TIMEOUT * 3)
 
-        self.assertTrue(wpan_table_parser.is_associated(self.sed), 'SED is still not associated!!!')
+        self.assertTrue(wpan_table_parser.is_associated(self.sed), "SED is still not associated!!!")
 
     @testcase.test_method_decorator
     def test09_verify_supervision_message(self):
-
         self.router.setprop(wpan.WPAN_CHILD_SUPERVISION_INTERVAL, str(PARENT_SUPERVISION_INTERVAL))
 
-        self.child_supervision_msg = ' Sending supervision message to child'
-        result = verify_within(self.find_string_in_log_file, PARENT_SUPERVISION_INTERVAL*10)
-        self.assertTrue(result, 'Cannot find the expected string:{} in log file !!!'.format(self.child_supervision_msg))
+        self.child_supervision_msg = "Sending supervision message to child"
+        result = verify_within(self.find_string_in_log_file, PARENT_SUPERVISION_INTERVAL * 10)
+        self.assertTrue(result, ("Cannot find the expected string:"
+                                 " {} in log file !!!".format(self.child_supervision_msg)))
 
 
 if __name__ == "__main__":

--- a/silk/tests/openthread/ot_test_data_poll_interval.py
+++ b/silk/tests/openthread/ot_test_data_poll_interval.py
@@ -12,26 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from silk.config import wpan_constants as wpan
-import silk.node.fifteen_four_dev_board as ffdb
-from silk.node.wpan_node import WpanCredentials
-import silk.hw.hw_resource as hwr
-import silk.tests.testcase as testcase
-from silk.utils import process_cleanup
-from silk.tools.wpan_util import verify
-
 import random
-import unittest
 import time
+import unittest
+
+from silk.config import wpan_constants as wpan
+from silk.node.wpan_node import WpanCredentials
+from silk.tools.wpan_util import verify
+from silk.utils import process_cleanup
+import silk.hw.hw_resource as hwr
+import silk.node.fifteen_four_dev_board as ffdb
+import silk.tests.testcase as testcase
 
 hwr.global_instance()
+
 WAIT_TIME1 = 0.36  # in seconds
-WAIT_TIME2 = 0.2   # in seconds
+WAIT_TIME2 = 0.2  # in seconds
 
 
 class TestDataPollInterval(testcase.TestCase):
-    # -----------------------------------------------------------------------------------------------------------------------
-    # Test description: Verify transmission of data polls and poll interval change.
+    # Test description: Verify transmission of data polls and poll interval
+    # change.
     #
     # Network Topology:
     #
@@ -42,17 +43,20 @@ class TestDataPollInterval(testcase.TestCase):
     #
     # Test covers the following situations:
     #
-    # -verify the default poll interval is proper i.e it should be smaller than child_timeout
-    # -verify number of data polls with different poll intervals
-    # -verify behavior when poll interval is switched from long to short.
-    # -verify setting poll interval zero should use default poll interval (depending on child timeout)
-    # -verify change in "child timeout" results in change in default poll interval
+    # - Verify the default poll interval is proper i.e it should be smaller than
+    #   child_timeout
+    # - Verify number of data polls with different poll intervals
+    # - Verify behavior when poll interval is switched from long to short.
+    # - Verify setting poll interval zero should use default poll interval
+    #   (depending on child timeout)
+    # - Verify change in "child timeout" results in change in default poll
+    #   interval
 
     child_timeout = None
     default_poll_interval = None
 
     @classmethod
-    def hardwareSelect(cls):
+    def hardware_select(cls):
         cls.router = ffdb.ThreadDevBoard()
         cls.sed = ffdb.ThreadDevBoard()
 
@@ -62,7 +66,7 @@ class TestDataPollInterval(testcase.TestCase):
         # Check and clean up wpantund process if any left over
         process_cleanup.ps_cleanup()
 
-        cls.hardwareSelect()
+        cls.hardware_select()
 
         cls.router.set_logger(cls.logger)
         cls.sed.set_logger(cls.logger)
@@ -73,12 +77,10 @@ class TestDataPollInterval(testcase.TestCase):
         cls.router.set_up()
         cls.sed.set_up()
 
-        cls.network_data = WpanCredentials(
-            network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
-            psk="00112233445566778899aabbccdd{0:04x}".
-                format(random.randint(0, 0xffff)),
-            channel=random.randint(11, 25),
-            fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
+        cls.network_data = WpanCredentials(network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
+                                           psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
+                                           channel=random.randint(11, 25),
+                                           fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
 
         cls.thread_sniffer_init(cls.network_data.channel)
 
@@ -120,8 +122,8 @@ class TestDataPollInterval(testcase.TestCase):
         TestDataPollInterval.child_timeout = int(self.sed.get(wpan.WPAN_THREAD_CHILD_TIMEOUT), 0) * 1000
         TestDataPollInterval.default_poll_interval = int(self.sed.get(wpan.WPAN_POLL_INTERVAL), 0)
 
-        self.logger.info('verify condition: 0 < default_poll_interval <= child_timeout i.e. 0 < {} <= {}'
-                         .format(self.default_poll_interval, self.child_timeout))
+        self.logger.info("verify condition: 0 < default_poll_interval <= child_timeout"
+                         " i.e. 0 < {} <= {}".format(self.default_poll_interval, self.child_timeout))
         verify(0 < self.default_poll_interval <= self.child_timeout)
 
     @testcase.test_method_decorator
@@ -139,8 +141,8 @@ class TestDataPollInterval(testcase.TestCase):
             expected_polls = int(WAIT_TIME1 * 1000 / poll_interval)
             self.logger.info("poll interval {} ms, polls -> actual {}, expected {}".format(
                 poll_interval, actual_polls, expected_polls))
-            self.logger.info('verify condition: actual_polls >= expected_polls'
-                             ' i.e. {} >= {}'.format(actual_polls, expected_polls))
+            self.logger.info("verify condition: actual_polls >= expected_polls"
+                             " i.e. {} >= {}".format(actual_polls, expected_polls))
             verify(actual_polls >= expected_polls)
 
     @testcase.test_method_decorator
@@ -153,25 +155,25 @@ class TestDataPollInterval(testcase.TestCase):
         #  - This should immediately trigger a poll tx since 100 ms is
         #    already passed since last poll transmission.
 
-        self.sed.set(wpan.WPAN_POLL_INTERVAL, '5000')
+        self.sed.set(wpan.WPAN_POLL_INTERVAL, "5000")
         time.sleep(WAIT_TIME2)
         poll_count_before = int(self.sed.get(wpan.WPAN_NCP_COUNTER_TX_PKT_DATA_POLL), 0)
         self.sed.set(wpan.WPAN_POLL_INTERVAL, str(WAIT_TIME2 * 1000))
         time.sleep(0.01)
         poll_count_after = int(self.sed.get(wpan.WPAN_NCP_COUNTER_TX_PKT_DATA_POLL), 0)
-        self.logger.info('verify condition: poll count with poll interval 200ms > poll count with poll interval 5s'
-                         ' i.e. {} > {}'.format(poll_count_after, poll_count_before))
+        self.logger.info("verify condition: poll count with poll interval 200ms > poll count with poll interval 5s"
+                         " i.e. {} > {}".format(poll_count_after, poll_count_before))
         verify(poll_count_after > poll_count_before)
 
     @testcase.test_method_decorator
     def test05_verify_data_poll_with_poll_interval_zero(self):
         # Verify behavior when poll interval is set to zero.
-        self.sed.set(wpan.WPAN_POLL_INTERVAL, '0')
+        self.sed.set(wpan.WPAN_POLL_INTERVAL, "0")
 
         # Poll interval should use default interval again (based on child timeout).
-        self.logger.info('verify condition: setting poll interval 0ms should use default poll interval'
-                         ' again (based on child timeout) i.e. {} == {}'
-                         .format(int(self.sed.get(wpan.WPAN_POLL_INTERVAL), 0), self.default_poll_interval))
+        self.logger.info("verify condition: setting poll interval 0ms should use default poll interval"
+                         " again (based on child timeout) i.e. {} == {}".format(
+                             int(self.sed.get(wpan.WPAN_POLL_INTERVAL), 0), self.default_poll_interval))
         verify(int(self.sed.get(wpan.WPAN_POLL_INTERVAL), 0) == self.default_poll_interval)
 
     @testcase.test_method_decorator
@@ -180,10 +182,10 @@ class TestDataPollInterval(testcase.TestCase):
         self.sed.set(wpan.WPAN_THREAD_CHILD_TIMEOUT, str(self.child_timeout / 1000 * 2))
         new_default_interval = int(self.sed.get(wpan.WPAN_POLL_INTERVAL), 0)
 
-        self.logger.info('verify condition: default_poll_interval < new_default_poll_interval '
-                         '(created by double child timeout) <= child_timeout * 2'
-                         ' i.e. {} < {} <= {}'
-                         .format(self.default_poll_interval, new_default_interval, self.child_timeout * 2))
+        self.logger.info("verify condition: default_poll_interval < new_default_poll_interval "
+                         "(created by double child timeout) <= child_timeout * 2"
+                         " i.e. {} < {} <= {}".format(self.default_poll_interval, new_default_interval,
+                                                      self.child_timeout * 2))
         verify(self.default_poll_interval < new_default_interval <= self.child_timeout * 2)
 
         # reset the child timeout to default value

--- a/silk/tests/openthread/ot_test_form_network.py
+++ b/silk/tests/openthread/ot_test_form_network.py
@@ -12,17 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import range
-from silk.config import wpan_constants as wpan
-import silk.node.fifteen_four_dev_board as ffdb
-from silk.node.wpan_node import WpanCredentials
-import silk.hw.hw_resource as hwr
-import silk.tests.testcase as testcase
-from silk.utils import process_cleanup
-
 import random
-import unittest
 import time
+import unittest
+
+from silk.config import wpan_constants as wpan
+from silk.node.wpan_node import WpanCredentials
+from silk.utils import process_cleanup
+import silk.hw.hw_resource as hwr
+import silk.node.fifteen_four_dev_board as ffdb
+import silk.tests.testcase as testcase
 
 hwr.global_instance()
 
@@ -31,7 +30,7 @@ class TestFormNetwork(testcase.TestCase):
     poll_interval = 1000
 
     @classmethod
-    def hardwareSelect(cls):
+    def hardware_select(cls):
         cls.router = ffdb.ThreadDevBoard()
         cls.joiner_list = []
 
@@ -50,7 +49,7 @@ class TestFormNetwork(testcase.TestCase):
         # Check and clean up wpantund process if any left over
         process_cleanup.ps_cleanup()
 
-        cls.hardwareSelect()
+        cls.hardware_select()
 
         cls.add_test_device(cls.router)
 
@@ -61,12 +60,10 @@ class TestFormNetwork(testcase.TestCase):
             device.set_logger(cls.logger)
             device.set_up()
 
-        cls.network_data = WpanCredentials(
-            network_name = "SILK-{0:04X}".format(random.randint(0, 0xffff)),
-            psk = "00112233445566778899aabbccdd{0:04x}".
-                format(random.randint(0, 0xffff)),
-            channel = random.randint(11, 25),
-            fabric_id = "{0:06x}dead".format(random.randint(0, 0xffffff)))
+        cls.network_data = WpanCredentials(network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
+                                           psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
+                                           channel=random.randint(11, 25),
+                                           fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
 
         cls.thread_sniffer_init(cls.network_data.channel)
 
@@ -90,7 +87,7 @@ class TestFormNetwork(testcase.TestCase):
         for end_node in self.joiner_list:
             end_node.whitelist_node(self.router)
             self.router.whitelist_node(end_node)
-        
+
         # whitelisting nodes for full mesh
         mesh_nodes = self.device_list[:-2]
         for node in mesh_nodes:
@@ -98,8 +95,8 @@ class TestFormNetwork(testcase.TestCase):
                 if other_node is not node:
                     node.whitelist_node(other_node)
 
-        self.router.form(self.network_data, 'router')
-        self.router.permit_join(60*len(self.joiner_list))
+        self.router.form(self.network_data, "router")
+        self.router.permit_join(60 * len(self.joiner_list))
         self.wait_for_completion(self.device_list)
 
         self.logger.info(self.router.ip6_lla)
@@ -123,42 +120,43 @@ class TestFormNetwork(testcase.TestCase):
 
     @testcase.test_method_decorator
     def test02_GetWpanStatus(self):
-        leader_node_type = self.router.wpanctl('get', 'get '+wpan.WPAN_NODE_TYPE, 2).split('=')[1].strip()[1:-1]
-        self.assertTrue(leader_node_type == 'leader', 'Leader is not created correctly!!!')
+        leader_node_type = self.router.wpanctl("get", "get " + wpan.WPAN_NODE_TYPE, 2).split("=")[1].strip()[1:-1]
+        self.assertTrue(leader_node_type == "leader", "Leader is not created correctly!!!")
 
         for _ in range(30):
             router_list, sed_list = [], []
 
             for e in self.joiner_list[:-2]:
-                router_list.append(e.wpanctl('get', 'get '+wpan.WPAN_NODE_TYPE, 2).split('=')[1].strip()[1:-1])
+                router_list.append(e.wpanctl("get", "get " + wpan.WPAN_NODE_TYPE, 2).split("=")[1].strip()[1:-1])
 
             for e in self.joiner_list[-2:]:
-                sed_list.append(e.wpanctl('get', 'get '+wpan.WPAN_NODE_TYPE, 2).split('=')[1].strip()[1:-1])
+                sed_list.append(e.wpanctl("get", "get " + wpan.WPAN_NODE_TYPE, 2).split("=")[1].strip()[1:-1])
 
             print(router_list)
             print(sed_list)
 
-            if all(e == 'router' for e in router_list) and all(e == 'sleepy-end-device' for e in sed_list):
-                print('All End-node moved up to  Router.')
+            if all(e == "router" for e in router_list) and all(e == "sleepy-end-device" for e in sed_list):
+                print("All End-node moved up to  Router.")
                 break
             time.sleep(8)
         else:
-            self.assertFalse(True, 'Router cannot get into router role after 240 seconds timeout')
+            self.assertFalse(True, "Router cannot get into router role after 240 seconds timeout")
 
     @testcase.test_method_decorator
     def test03_PingRouterLLA(self):
-        self.ping6_multi_source(self.joiner_list, self.router.ip6_lla,
-                                num_pings=10, allowed_errors=5, ping_size=200)
+        self.ping6_multi_source(self.joiner_list, self.router.ip6_lla, num_pings=10, allowed_errors=5, ping_size=200)
 
     @testcase.test_method_decorator
     def test04_PingRouterMLA(self):
-        self.ping6_multi_source(self.joiner_list, self.router.ip6_mla,
-                                num_pings=10, allowed_errors=5, ping_size=200)
+        self.ping6_multi_source(self.joiner_list, self.router.ip6_mla, num_pings=10, allowed_errors=5, ping_size=200)
 
     @testcase.test_method_decorator
     def test05_PingRouterULA(self):
-        self.ping6_multi_source(self.joiner_list, self.router.ip6_thread_ula,
-                                num_pings=10, allowed_errors=5, ping_size=200)
+        self.ping6_multi_source(self.joiner_list,
+                                self.router.ip6_thread_ula,
+                                num_pings=10,
+                                allowed_errors=5,
+                                ping_size=200)
 
 
 if __name__ == "__main__":

--- a/silk/tests/openthread/ot_test_inform_previous_parent.py
+++ b/silk/tests/openthread/ot_test_inform_previous_parent.py
@@ -12,20 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import str
-from builtins import range
-from silk.config import wpan_constants as wpan
-import silk.node.fifteen_four_dev_board as ffdb
-from silk.node.wpan_node import WpanCredentials
-from silk.tools import wpan_table_parser
-import silk.hw.hw_resource as hwr
-import silk.tests.testcase as testcase
-from silk.tools.wpan_util import verify, verify_within, is_associated
-from silk.utils import process_cleanup
-
 import random
 import time
 import unittest
+
+from silk.config import wpan_constants as wpan
+from silk.node.wpan_node import WpanCredentials
+from silk.tools import wpan_table_parser
+from silk.tools.wpan_util import verify, verify_within, is_associated
+from silk.utils import process_cleanup
+import silk.hw.hw_resource as hwr
+import silk.node.fifteen_four_dev_board as ffdb
+import silk.tests.testcase as testcase
 
 hwr.global_instance()
 
@@ -38,9 +36,9 @@ class TestInformPreviousParent(testcase.TestCase):
     poll_interval = 300
 
     @classmethod
-    def hardwareSelect(cls):
+    def hardware_select(cls):
         cls.parent1 = ffdb.ThreadDevBoard()
-        cls.parent2= ffdb.ThreadDevBoard()
+        cls.parent2 = ffdb.ThreadDevBoard()
         cls.child1 = ffdb.ThreadDevBoard()
 
     @classmethod
@@ -49,7 +47,7 @@ class TestInformPreviousParent(testcase.TestCase):
         # Check and clean up wpantund process if any left over
         process_cleanup.ps_cleanup()
 
-        cls.hardwareSelect()
+        cls.hardware_select()
 
         cls.add_test_device(cls.parent1)
         cls.add_test_device(cls.parent2)
@@ -59,11 +57,10 @@ class TestInformPreviousParent(testcase.TestCase):
             device.set_logger(cls.logger)
             device.set_up()
 
-        cls.network_data = WpanCredentials(
-            network_name = "SILK-{0:04X}".format(random.randint(0, 0xffff)),
-            psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
-            channel=random.randint(11, 25),
-            fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
+        cls.network_data = WpanCredentials(network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
+                                           psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
+                                           channel=random.randint(11, 25),
+                                           fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
 
         cls.thread_sniffer_init(cls.network_data.channel)
 
@@ -99,7 +96,7 @@ class TestInformPreviousParent(testcase.TestCase):
         self.parent2.whitelist_node(self.parent1)
         self.parent2.whitelist_node(self.child1)
 
-        self.parent1.form(self.network_data, 'router')
+        self.parent1.form(self.network_data, "router")
         self.parent1.permit_join(120)
         self.wait_for_completion(self.device_list)
 
@@ -118,15 +115,15 @@ class TestInformPreviousParent(testcase.TestCase):
         self.child1.setprop(wpan.WPAN_THREAD_CHILD_TIMEOUT, str(CHILD_TIMEOUT))
 
         for _ in range(10):
-            node_type = self.parent2.wpanctl('get', 'get ' + wpan.WPAN_NODE_TYPE, 2).split('=')[1].strip()[1:-1]
-            print(node_type == 'router')
+            node_type = self.parent2.wpanctl("get", "get " + wpan.WPAN_NODE_TYPE, 2).split("=")[1].strip()[1:-1]
+            print(node_type == "router")
 
-            if node_type == 'router':
-                print('End-node moved up to a Router.')
+            if node_type == "router":
+                print("End-node moved up to a Router.")
                 break
             time.sleep(10)
         else:
-            self.assertFalse(True, 'Router cannot get into router role after 100 seconds timeout')
+            self.assertFalse(True, "Router cannot get into router role after 100 seconds timeout")
 
     @testcase.test_method_decorator
     def test02_Verify_ChildTable(self):

--- a/silk/tests/openthread/ot_test_leader_loss.py
+++ b/silk/tests/openthread/ot_test_leader_loss.py
@@ -12,19 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from silk.config import wpan_constants as wpan
-from silk.tools import wpan_table_parser
-
-import silk.node.fifteen_four_dev_board as ffdb
-from silk.node.wpan_node import WpanCredentials
-import silk.hw.hw_resource as hwr
-import silk.tests.testcase as testcase
-from silk.utils import process_cleanup
-from silk.tools.wpan_util import verify, verify_within
-
 import random
-import unittest
 import time
+import unittest
+
+from silk.config import wpan_constants as wpan
+from silk.node.wpan_node import WpanCredentials
+from silk.tools import wpan_table_parser
+from silk.tools.wpan_util import verify, verify_within
+from silk.utils import process_cleanup
+import silk.hw.hw_resource as hwr
+import silk.node.fifteen_four_dev_board as ffdb
+import silk.tests.testcase as testcase
 
 hwr.global_instance()
 ROLE_WAIT_TIME = 180
@@ -33,7 +32,6 @@ NUM_CHILDREN = 1
 
 
 class TestLeaderLoss(testcase.TestCase):
-    # -----------------------------------------------------------------------------------------------------------------------
     # Test description: LeaderLoss
     #
     # Network Topology:
@@ -55,7 +53,7 @@ class TestLeaderLoss(testcase.TestCase):
     #
 
     @classmethod
-    def hardwareSelect(cls):
+    def hardware_select(cls):
         cls.r1 = ffdb.ThreadDevBoard()
         cls.r2 = ffdb.ThreadDevBoard()
         cls.r3 = ffdb.ThreadDevBoard()
@@ -72,7 +70,7 @@ class TestLeaderLoss(testcase.TestCase):
         # Check and clean up wpantund process if any left over
         process_cleanup.ps_cleanup()
 
-        cls.hardwareSelect()
+        cls.hardware_select()
 
         for device in cls.all_nodes:
 
@@ -81,12 +79,10 @@ class TestLeaderLoss(testcase.TestCase):
 
             device.set_up()
 
-        cls.network_data = WpanCredentials(
-            network_name="MORTAR-{0:04X}".format(random.randint(0, 0xffff)),
-            psk="00112233445566778899aabbccdd{0:04x}".
-                format(random.randint(0, 0xffff)),
-            channel=random.randint(11, 25),
-            fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
+        cls.network_data = WpanCredentials(network_name="MORTAR-{0:04X}".format(random.randint(0, 0xffff)),
+                                           psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
+                                           channel=random.randint(11, 25),
+                                           fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
 
         cls.thread_sniffer_init(cls.network_data.channel)
 
@@ -106,11 +102,12 @@ class TestLeaderLoss(testcase.TestCase):
 
     def _verify_device_role(self, device, expect_role):
         """
-        verify device role
-        """
+    verify device role
+    """
+
         def check_device_role():
-            node_type = device.wpanctl('get', 'get ' + wpan.WPAN_NODE_TYPE, 2).split('=')[1].strip()[1:-1]
-            self.logger.info('Node type for {} is {} currently, expect to be {}'.format(
+            node_type = device.wpanctl("get", "get " + wpan.WPAN_NODE_TYPE, 2).split("=")[1].strip()[1:-1]
+            self.logger.info("Node type for {} is {} currently, expect to be {}".format(
                 device.device_path, node_type, expect_role))
             verify(node_type == expect_role)
 
@@ -119,13 +116,13 @@ class TestLeaderLoss(testcase.TestCase):
 
     def _verify_devices_roles(self, devices_roles):
         # verify devices only one is leader and rest are routers
-        leader_count = devices_roles.count('leader')
-        router_count = devices_roles.count('router')
-        if leader_count == 1 and router_count == len(devices_roles)-1:
+        leader_count = devices_roles.count("leader")
+        router_count = devices_roles.count("router")
+        if leader_count == 1 and router_count == len(devices_roles) - 1:
             return True
         else:
             self.logger.info("leader count is {}, should be 1".format(leader_count))
-            self.logger.info("router count is {}, should be {}".format(router_count, len(devices_roles)-1))
+            self.logger.info("router count is {}, should be {}".format(router_count, len(devices_roles) - 1))
             return False
 
     def _verify_children(self, device, children_num):
@@ -164,10 +161,10 @@ class TestLeaderLoss(testcase.TestCase):
         self.network_data.xpanid = self.r1.xpanid
         self.network_data.panid = self.r1.panid
 
-        self.r2.join(self.network_data, 'router')
+        self.r2.join(self.network_data, "router")
         self.wait_for_completion(self.device_list)
 
-        self.r3.join(self.network_data, 'router')
+        self.r3.join(self.network_data, "router")
         self.wait_for_completion(self.device_list)
 
         self.fed1.join(self.network_data, "end-node")
@@ -184,32 +181,33 @@ class TestLeaderLoss(testcase.TestCase):
             self.r1.device_path, self.r2.device_path, self.r3.device_path))
         # verify r1 role is leader
         r1_result = self._verify_device_role(self.r1, "leader")
-        self.assertTrue(r1_result, 'r1 cannot get into leader role after {} seconds timeout'.format(ROLE_WAIT_TIME))
+        self.assertTrue(r1_result, "r1 cannot get into leader role after {} seconds timeout".format(ROLE_WAIT_TIME))
 
         # verify r2 role is router
         r2_result = self._verify_device_role(self.r2, "router")
-        self.assertTrue(r2_result, 'r2 cannot get into router role after {} seconds timeout'.format(ROLE_WAIT_TIME))
+        self.assertTrue(r2_result, "r2 cannot get into router role after {} seconds timeout".format(ROLE_WAIT_TIME))
 
         # verify r3 role is router
         r3_result = self._verify_device_role(self.r3, "router")
-        self.assertTrue(r3_result, 'r3 cannot get into router role after {} seconds timeout'.format(ROLE_WAIT_TIME))
+        self.assertTrue(r3_result, "r3 cannot get into router role after {} seconds timeout".format(ROLE_WAIT_TIME))
 
     @testcase.test_method_decorator
     def test02_reset_r1(self):
         """
-        reset r1, verify r2 or r3 becomes leader, the other one stays as router
-        """
+    reset r1, verify r2 or r3 becomes leader, the other one stays as router
+    """
         self.r1.reset_thread_radio()
         self.wait_for_completion(self.device_list)
 
         # verify r2, r3 role, one of them change to be leader
-        r1_role = self.r1.wpanctl('get', 'get ' + wpan.WPAN_NODE_TYPE, 2).split('=')[1].strip()[1:-1]
-        r2_role = self.r2.wpanctl('get', 'get ' + wpan.WPAN_NODE_TYPE, 2).split('=')[1].strip()[1:-1]
-        r3_role = self.r3.wpanctl('get', 'get ' + wpan.WPAN_NODE_TYPE, 2).split('=')[1].strip()[1:-1]
+        r1_role = self.r1.wpanctl("get", "get " + wpan.WPAN_NODE_TYPE, 2).split("=")[1].strip()[1:-1]
+        r2_role = self.r2.wpanctl("get", "get " + wpan.WPAN_NODE_TYPE, 2).split("=")[1].strip()[1:-1]
+        r3_role = self.r3.wpanctl("get", "get " + wpan.WPAN_NODE_TYPE, 2).split("=")[1].strip()[1:-1]
         devices_roles = [r1_role, r2_role, r3_role]
         roles_result = self._verify_devices_roles(devices_roles)
-        self.assertTrue(roles_result,
-                        'r1, r2, r3 only one can be leader, r1 is {}, r2 is {}, r3 is {}'.format(r1_role, r2_role, r3_role))
+        self.assertTrue(
+            roles_result,
+            "r1, r2, r3 only one can be leader, r1 is {}, r2 is {}, r3 is {}".format(r1_role, r2_role, r3_role))
 
         # verify their children stayed with their parents
         self._verify_children(self.r1, NUM_CHILDREN)
@@ -219,10 +217,10 @@ class TestLeaderLoss(testcase.TestCase):
     @testcase.test_method_decorator
     def test03_r1_leave_network(self):
         """
-        unwhitelist r1 out
-        r1 leave the network
-        verify either r2 or r3 is leader, the other one is router
-        """
+    unwhitelist r1 out
+    r1 leave the network
+    verify either r2 or r3 is leader, the other one is router
+    """
         self.r2.un_whitelist_node(self.r1)
         self.r3.un_whitelist_node(self.r1)
         self.r1.un_whitelist_node(self.r2)
@@ -230,25 +228,25 @@ class TestLeaderLoss(testcase.TestCase):
 
         self.r1.leave()
         self.wait_for_completion(self.device_list)
-        # total wait for minutes (default is 5m) for one router to change to leader,
-        # but it will break out if one router changed to leader early
+        # total wait for minutes (default is 5m) for one router to change
+        # to leader, but it will break out if one router changed to leader early
         timeout = time.time() + LEADER_CHANGE_WAIT_TIME
         while True:
             if time.time() > timeout:
                 break
             for device in self.all_nodes[1:]:
-                node_type = device.wpanctl('get', 'get ' + wpan.WPAN_NODE_TYPE, 2)
-                role = node_type.split('=')[1].strip()[1:-1]
+                node_type = device.wpanctl("get", "get " + wpan.WPAN_NODE_TYPE, 2)
+                role = node_type.split("=")[1].strip()[1:-1]
             time.sleep(30)
             # verify r2, r3 role, one of them change to be leader
-            r2_role = self.r2.wpanctl('get', 'get ' + wpan.WPAN_NODE_TYPE, 2).split('=')[1].strip()[1:-1]
-            r3_role = self.r3.wpanctl('get', 'get ' + wpan.WPAN_NODE_TYPE, 2).split('=')[1].strip()[1:-1]
-            roles_result = (r2_role == "leader" and r3_role == "router") or (r3_role == "leader" and r2_role == "router")
+            r2_role = self.r2.wpanctl("get", "get " + wpan.WPAN_NODE_TYPE, 2).split("=")[1].strip()[1:-1]
+            r3_role = self.r3.wpanctl("get", "get " + wpan.WPAN_NODE_TYPE, 2).split("=")[1].strip()[1:-1]
+            roles_result = (r2_role == "leader" and r3_role == "router") or (r3_role == "leader" and
+                                                                             r2_role == "router")
             if roles_result:
                 break
 
-        self.assertTrue(roles_result, 'r2, r3 nobody change to leader in 5m, r2 is {},'
-                                      'r3 is {}'.format(r2_role, r3_role))
+        self.assertTrue(roles_result, ("r2, r3 nobody change to leader in 5m," f" r2 is {r2_role}, r3 is {r3_role}"))
 
         # verify their children stayed with their parents
         self._verify_children(self.r2, NUM_CHILDREN)
@@ -257,8 +255,8 @@ class TestLeaderLoss(testcase.TestCase):
     @testcase.test_method_decorator
     def test04_r1_join_network(self):
         """
-        r1 re-join network as router
-        """
+    r1 re-join network as router
+    """
         self.r1.whitelist_node(self.r2)
         self.r2.whitelist_node(self.r1)
 
@@ -269,12 +267,12 @@ class TestLeaderLoss(testcase.TestCase):
         self.r3.whitelist_node(self.r1)
         self.wait_for_completion(self.device_list)
 
-        self.r1.join(self.network_data, 'router')
+        self.r1.join(self.network_data, "router")
         self.wait_for_completion(self.device_list)
 
         # verify r1 role is router
         r1_result = self._verify_device_role(self.r1, "router")
-        self.assertTrue(r1_result, 'r1 cannot get into router role after {} seconds timeout'.format(ROLE_WAIT_TIME))
+        self.assertTrue(r1_result, ("r1 cannot get into router role" f" after {ROLE_WAIT_TIME} seconds timeout"))
         time.sleep(120)
 
         # verify their children stayed with their parents

--- a/silk/tests/openthread/ot_test_meshcop_joiner_commissioner.py
+++ b/silk/tests/openthread/ot_test_meshcop_joiner_commissioner.py
@@ -12,24 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from silk.config import wpan_constants as wpan
-import silk.node.fifteen_four_dev_board as ffdb
-import silk.hw.hw_resource as hwr
-import silk.tests.testcase as testcase
-from silk.utils import process_cleanup
-from silk.tools.wpan_util import verify, verify_within, is_associated
-
 import random
 import unittest
+
+from silk.config import wpan_constants as wpan
+from silk.tools.wpan_util import verify, verify_within, is_associated
+from silk.utils import process_cleanup
+import silk.hw.hw_resource as hwr
+import silk.node.fifteen_four_dev_board as ffdb
+import silk.tests.testcase as testcase
 
 hwr.global_instance()
 WAIT_TIME = 2  # seconds
 
-PSKd = '123456'
+PSKd = "123456"
 
 
 class TestMeshcopJoinerCommissioner(testcase.TestCase):
-    # -----------------------------------------------------------------------------------------------------------------------
     # Test description: Test MeshCop Joiner and Commissioner behavior
     #
     # This test covers Thread commissioning with a single commissioner and joiner device.
@@ -45,7 +44,7 @@ class TestMeshcopJoinerCommissioner(testcase.TestCase):
     # Verify after commissioning joiner device is able to attach to commissioner successfully.
 
     @classmethod
-    def hardwareSelect(cls):
+    def hardware_select(cls):
         cls.commissioner = ffdb.ThreadDevBoard()
         cls.joiner = ffdb.ThreadDevBoard()
 
@@ -55,7 +54,7 @@ class TestMeshcopJoinerCommissioner(testcase.TestCase):
         # Check and clean up wpantund process if any left over
         process_cleanup.ps_cleanup()
 
-        cls.hardwareSelect()
+        cls.hardware_select()
 
         cls.commissioner.set_logger(cls.logger)
         cls.joiner.set_logger(cls.logger)
@@ -84,10 +83,11 @@ class TestMeshcopJoinerCommissioner(testcase.TestCase):
     def test01_form_network_on_commissioner(self):
         self.network_name = "SILK-{0:04X}".format(random.randint(0, 0xffff))
         cmd = "form {}".format(self.network_name)
-        self.commissioner.wpanctl_async('form', cmd, "Successfully formed!", 20)
+        self.commissioner.wpanctl_async("form", cmd, "Successfully formed!", 20)
         self.wait_for_completion(self.device_list)
-        leader_node_type = self.commissioner.wpanctl('get', 'get '+wpan.WPAN_NODE_TYPE, 2).split('=')[1].strip()[1:-1]
-        self.assertTrue(leader_node_type == 'leader', 'Leader is not created correctly!!!')
+        leader_node_type = self.commissioner.wpanctl("get", "get " + wpan.WPAN_NODE_TYPE,
+                                                     2).split("=")[1].strip()[1:-1]
+        self.assertTrue(leader_node_type == "leader", "Leader is not created correctly!!!")
 
     @testcase.test_method_decorator
     def test02_start_commissioning(self):

--- a/silk/tests/openthread/ot_test_multicast_addresses.py
+++ b/silk/tests/openthread/ot_test_multicast_addresses.py
@@ -12,18 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from silk.config import wpan_constants as wpan
-from silk.tools.wpan_util import verify
-from silk.tools import wpan_table_parser
-
-import silk.node.fifteen_four_dev_board as ffdb
-from silk.node.wpan_node import WpanCredentials
-import silk.hw.hw_resource as hwr
-import silk.tests.testcase as testcase
-from silk.utils import process_cleanup
-
 import random
 import unittest
+
+from silk.config import wpan_constants as wpan
+from silk.node.wpan_node import WpanCredentials
+from silk.tools import wpan_table_parser
+from silk.tools.wpan_util import verify
+from silk.utils import process_cleanup
+import silk.hw.hw_resource as hwr
+import silk.node.fifteen_four_dev_board as ffdb
+import silk.tests.testcase as testcase
 
 hwr.global_instance()
 
@@ -34,9 +33,9 @@ class TestMulticastAddresses(testcase.TestCase):
     poll_interval = 800
 
     @classmethod
-    def hardwareSelect(cls):
+    def hardware_select(cls):
         cls.r1 = ffdb.ThreadDevBoard()
-        cls.fed= ffdb.ThreadDevBoard()
+        cls.fed = ffdb.ThreadDevBoard()
         cls.sed = ffdb.ThreadDevBoard()
 
         cls.all_nodes = [cls.r1, cls.fed, cls.sed]
@@ -47,7 +46,7 @@ class TestMulticastAddresses(testcase.TestCase):
         # Check and clean up wpantund process if any left over
         process_cleanup.ps_cleanup()
 
-        cls.hardwareSelect()
+        cls.hardware_select()
 
         for device in cls.all_nodes:
 
@@ -56,11 +55,10 @@ class TestMulticastAddresses(testcase.TestCase):
 
             device.set_up()
 
-        cls.network_data = WpanCredentials(
-            network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
-            psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
-            channel=random.randint(11, 25),
-            fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
+        cls.network_data = WpanCredentials(network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
+                                           psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
+                                           channel=random.randint(11, 25),
+                                           fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
 
         cls.thread_sniffer_init(cls.network_data.channel)
 
@@ -96,7 +94,7 @@ class TestMulticastAddresses(testcase.TestCase):
         self.network_data.xpanid = self.r1.xpanid
         self.network_data.panid = self.r1.panid
 
-        self.fed.join(self.network_data, 'end-node')
+        self.fed.join(self.network_data, "end-node")
         self.wait_for_completion(self.device_list)
 
         self.sed.join(self.network_data, "sleepy-end-device")
@@ -109,11 +107,11 @@ class TestMulticastAddresses(testcase.TestCase):
     @testcase.test_method_decorator
     def test02_Verify_Multicast_Addresses(self):
         # Get the mesh-local prefix (remove the "/64" at the end of the string)
-        ml_prefix = self.r1.get(wpan.WPAN_IP6_MESH_LOCAL_PREFIX)[1:-1].split('/')[0]
+        ml_prefix = self.r1.get(wpan.WPAN_IP6_MESH_LOCAL_PREFIX)[1:-1].split("/")[0]
 
         # Derive the link-local/realm-local all thread nodes multicast addresses
-        ll_all_thread_nodes_addr = 'ff32:40:' + ml_prefix + '1'
-        rl_all_thread_nodes_addr = 'ff33:40:' + ml_prefix + '1'
+        ll_all_thread_nodes_addr = "ff32:40:" + ml_prefix + "1"
+        rl_all_thread_nodes_addr = "ff33:40:" + ml_prefix + "1"
 
         # List of multicast addresses subscribed by all nodes
         mcast_addrs = [

--- a/silk/tests/openthread/ot_test_neighbor_table.py
+++ b/silk/tests/openthread/ot_test_neighbor_table.py
@@ -12,33 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import range
+import random
+import time
+import unittest
+
 from silk.config import wpan_constants as wpan
-import silk.node.fifteen_four_dev_board as ffdb
 from silk.node.wpan_node import WpanCredentials
 from silk.tools import wpan_table_parser
-import silk.hw.hw_resource as hwr
-import silk.tests.testcase as testcase
 from silk.utils import process_cleanup
+import silk.hw.hw_resource as hwr
+import silk.node.fifteen_four_dev_board as ffdb
+import silk.tests.testcase as testcase
 
-import random
-import unittest
-import time
 hwr.global_instance()
 
 NUM_ROUTERS = 2
 NUM_CHILDREN = 1
 
-NEIGHBOR_TABLE_AS_VALMAP_ENTRY = ("Age", "AverageRssi", "ExtAddress", "FullFunction", "FullNetworkData",
-                                  "IsChild", "LastRssi", "LinkFrameCounter", "LinkQualityIn", "MleFrameCounter",
-                                  "RLOC16", "RxOnWhenIdle", "SecureDataRequest")
+NEIGHBOR_TABLE_AS_VALMAP_ENTRY = ("Age", "AverageRssi", "ExtAddress", "FullFunction", "FullNetworkData", "IsChild",
+                                  "LastRssi", "LinkFrameCounter", "LinkQualityIn", "MleFrameCounter", "RLOC16",
+                                  "RxOnWhenIdle", "SecureDataRequest")
 
 
 class TestNeighborTable(testcase.TestCase):
     # Minimum Three devices: One each for leader, router, sed
 
     @classmethod
-    def hardwareSelect(cls):
+    def hardware_select(cls):
         cls.routers = []
         for num in range(NUM_ROUTERS):
             cls.routers.append(ffdb.ThreadDevBoard())
@@ -58,9 +58,9 @@ class TestNeighborTable(testcase.TestCase):
         # Check and clean up wpantund process if any left over
         process_cleanup.ps_cleanup()
 
-        cls.hardwareSelect()
+        cls.hardware_select()
 
-        for device in cls.routers+cls.children+cls.ed[1:]:
+        for device in cls.routers + cls.children + cls.ed[1:]:
             cls.add_test_device(device)
 
         for device in cls.device_list:
@@ -71,11 +71,11 @@ class TestNeighborTable(testcase.TestCase):
         cls.network_data_list = []
 
         for i in range(total_networks):
-            cls.network_data_list.append(WpanCredentials(
-                network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
-                psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
-                channel=random.randint(11, 25),
-                fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff))))
+            cls.network_data_list.append(
+                WpanCredentials(network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
+                                psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
+                                channel=random.randint(11, 25),
+                                fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff))))
 
         cls.thread_sniffer_init(cls.network_data_list[0].channel)
 
@@ -112,7 +112,7 @@ class TestNeighborTable(testcase.TestCase):
             self.routers[num].whitelist_node(self.ed[num])
 
         # Form the Network
-        self.routers[0].form(self.network_data_list[0], 'router')
+        self.routers[0].form(self.network_data_list[0], "router")
         self.wait_for_completion(self.device_list)
 
         self.logger.info(self.routers[0].ip6_lla)
@@ -122,28 +122,28 @@ class TestNeighborTable(testcase.TestCase):
         self.network_data_list[0].panid = self.routers[0].panid
 
         for i, router in enumerate(self.routers[1:]):
-            router.join(self.network_data_list[0], 'router')
+            router.join(self.network_data_list[0], "router")
             self.wait_for_completion(self.device_list)
 
         for num in range(1, NUM_ROUTERS):
-            self.ed[num].join(self.network_data_list[0], 'end-node')
+            self.ed[num].join(self.network_data_list[0], "end-node")
             self.wait_for_completion(self.device_list)
 
         for num in range(NUM_CHILDREN):
-            self.children[num].join(self.network_data_list[0], 'sleepy-end-device')
+            self.children[num].join(self.network_data_list[0], "sleepy-end-device")
             self.children[num].set_sleep_poll_interval(300)
             self.wait_for_completion(self.device_list)
 
         for _ in range(10):
-            node_type = self.routers[1].wpanctl('get', 'get '+wpan.WPAN_NODE_TYPE, 2).split('=')[1].strip()[1:-1]
-            print(node_type == 'router')
+            node_type = self.routers[1].wpanctl("get", "get " + wpan.WPAN_NODE_TYPE, 2).split("=")[1].strip()[1:-1]
+            print(node_type == "router")
 
-            if node_type == 'router':
-                print('End-node moved up to a Router.')
+            if node_type == "router":
+                print("End-node moved up to a Router.")
                 break
             time.sleep(10)
         else:
-            self.assertFalse(True, 'Router cannot get into router role after 100 seconds timeout')
+            self.assertFalse(True, "Router cannot get into router role after 100 seconds timeout")
 
         for device in self.device_list:
             ret = device.wpanctl("get", "status", 2)
@@ -153,27 +153,28 @@ class TestNeighborTable(testcase.TestCase):
     def test02_Verify_Router_Type(self):
         for router in self.routers[1:]:
             node_type = router.get(wpan.WPAN_NODE_TYPE).strip()
-            self.assertEqual(node_type, wpan.NODE_TYPE_ROUTER, 'Node Type is: {} vs expected: {}'.format(node_type, wpan.NODE_TYPE_ROUTER))
+            self.assertEqual(node_type, wpan.NODE_TYPE_ROUTER,
+                             "Node Type is: {} vs expected: {}".format(node_type, wpan.NODE_TYPE_ROUTER))
 
     @testcase.test_method_decorator
     def test03_Verify_Children(self):
-        neighborTable = self.routers[0].wpanctl("get", "get "+wpan.WPAN_THREAD_NEIGHBOR_TABLE, 2)
-        neighborTable = wpan_table_parser.parse_neighbor_table_result(neighborTable)
+        neighbor_table = self.routers[0].wpanctl("get", "get " + wpan.WPAN_THREAD_NEIGHBOR_TABLE, 2)
+        neighbor_table = wpan_table_parser.parse_neighbor_table_result(neighbor_table)
 
-        print(neighborTable)
+        print(neighbor_table)
 
-        self.assertEqual(len(neighborTable), len(self.routers)-1+len(self.children))
+        self.assertEqual(len(neighbor_table), len(self.routers) - 1 + len(self.children))
 
         # Verify that all children are seen in the neighbor table
 
         for child in self.children:
             ext_addr = child.getprop(wpan.WPAN_EXT_ADDRESS)[1:-1]
 
-            for entry in neighborTable:
+            for entry in neighbor_table:
                 if entry.ext_address == ext_addr:
                     break
             else:
-                self.assertTrue(0, 'Failed to find a child entry for extended address {} in table'.format(ext_addr))
+                self.assertTrue(0, "Failed to find a child entry for extended address {} in table".format(ext_addr))
 
             self.assertEqual(int(entry.rloc16, 16), int(child.getprop(wpan.WPAN_THREAD_RLOC16), 16))
             self.assertFalse(entry.is_ftd())
@@ -183,41 +184,39 @@ class TestNeighborTable(testcase.TestCase):
     @testcase.test_method_decorator
     def test04_Verify_Router(self):
         # Verify that all other routers are seen in the neighbor table
-        neighborTable = self.routers[0].wpanctl("get", "get " + wpan.WPAN_THREAD_NEIGHBOR_TABLE, 2)
-        neighborTable = wpan_table_parser.parse_neighbor_table_result(neighborTable)
+        neighbor_table = self.routers[0].wpanctl("get", "get " + wpan.WPAN_THREAD_NEIGHBOR_TABLE, 2)
+        neighbor_table = wpan_table_parser.parse_neighbor_table_result(neighbor_table)
 
-        print(neighborTable)
+        print(neighbor_table)
 
-        self.assertEqual(len(neighborTable), len(self.routers)-1+len(self.children))
+        self.assertEqual(len(neighbor_table), len(self.routers) - 1 + len(self.children))
 
         # Verify that all children are seen in the neighbor table
 
         for router in self.routers[1:]:
             ext_addr = router.getprop(wpan.WPAN_EXT_ADDRESS)[1:-1]
 
-            for entry in neighborTable:
+            for entry in neighbor_table:
                 if entry.ext_address == ext_addr:
                     break
             else:
-                self.assertTrue(0, 'Failed to find a router entry for extended address {} in table'.format(
-                    ext_addr))
+                self.assertTrue(0, "Failed to find a router entry for extended address {} in table".format(ext_addr))
             self.assertEqual(int(entry.rloc16, 16), int(router.getprop(wpan.WPAN_THREAD_RLOC16), 16))
 
             self.assertTrue(entry.is_ftd())
             self.assertTrue(entry.is_rx_on_when_idle())
             self.assertFalse(entry.is_child())
 
-
     @testcase.test_method_decorator
     def test05_Verify_NeighborTable_AsValMap(self):
-        neighborTable = self.routers[0].wpanctl("get", "get "+wpan.WPAN_THREAD_NEIGHBOR_TABLE_ASVALMAP, 2)
+        neighbor_table = self.routers[0].wpanctl("get", "get " + wpan.WPAN_THREAD_NEIGHBOR_TABLE_ASVALMAP, 2)
 
-        print(neighborTable)
+        print(neighbor_table)
 
         total_neighbor_table_entry = len(self.routers) - 1 + len(self.children)
 
         for item in NEIGHBOR_TABLE_AS_VALMAP_ENTRY:
-            self.assertEqual(neighborTable.count(item), total_neighbor_table_entry)
+            self.assertEqual(neighbor_table.count(item), total_neighbor_table_entry)
 
 
 if __name__ == "__main__":

--- a/silk/tests/openthread/ot_test_network_data_timeout.py
+++ b/silk/tests/openthread/ot_test_network_data_timeout.py
@@ -12,17 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from silk.config import wpan_constants as wpan
-import silk.node.fifteen_four_dev_board as ffdb
-from silk.node.wpan_node import WpanCredentials
-import silk.hw.hw_resource as hwr
-import silk.tests.testcase as testcase
-from silk.utils import process_cleanup
-from silk.tools.wpan_util import verify_within, verify_prefix_with_rloc16, verify_no_prefix_with_rloc16
-
 import random
-import unittest
 import time
+import unittest
+
+from silk.config import wpan_constants as wpan
+from silk.node.wpan_node import WpanCredentials
+from silk.tools.wpan_util import (verify_within, verify_prefix_with_rloc16, verify_no_prefix_with_rloc16)
+from silk.utils import process_cleanup
+import silk.hw.hw_resource as hwr
+import silk.node.fifteen_four_dev_board as ffdb
+import silk.tests.testcase as testcase
 
 hwr.global_instance()
 
@@ -36,7 +36,6 @@ PREFIX_SYNC_WAIT_AFTER_ROUTER_REMOVAL = 240  # in seconds
 
 
 class TestNetworkDataTimeout(testcase.TestCase):
-    # -----------------------------------------------------------------------------------------------------------------------
     # Test description: Network Data (on-mesh prefix) timeout and entry removal
     #
     # Network topology:
@@ -58,7 +57,7 @@ class TestNetworkDataTimeout(testcase.TestCase):
     poll_interval = 400
 
     @classmethod
-    def hardwareSelect(cls):
+    def hardware_select(cls):
         cls.r1 = ffdb.ThreadDevBoard()
         cls.r2 = ffdb.ThreadDevBoard()
         cls.sed1 = ffdb.ThreadDevBoard()
@@ -71,7 +70,7 @@ class TestNetworkDataTimeout(testcase.TestCase):
         # Check and clean up wpantund process if any left over
         process_cleanup.ps_cleanup()
 
-        cls.hardwareSelect()
+        cls.hardware_select()
 
         for device in cls.all_nodes:
 
@@ -80,11 +79,10 @@ class TestNetworkDataTimeout(testcase.TestCase):
 
             device.set_up()
 
-        cls.network_data = WpanCredentials(
-            network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
-            psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
-            channel=random.randint(11, 25),
-            fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
+        cls.network_data = WpanCredentials(network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
+                                           psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
+                                           channel=random.randint(11, 25),
+                                           fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
 
         cls.thread_sniffer_init(cls.network_data.channel)
 
@@ -120,7 +118,7 @@ class TestNetworkDataTimeout(testcase.TestCase):
         self.network_data.xpanid = self.r1.xpanid
         self.network_data.panid = self.r1.panid
 
-        self.r2.join(self.network_data, 'router')
+        self.r2.join(self.network_data, "router")
         self.wait_for_completion(self.device_list)
 
         self.sed1.join(self.network_data, "sleepy-end-device")
@@ -128,19 +126,19 @@ class TestNetworkDataTimeout(testcase.TestCase):
         self.wait_for_completion(self.device_list)
 
         for _ in range(10):
-            node_type = self.r2.wpanctl('get', 'get '+wpan.WPAN_NODE_TYPE, 2).split('=')[1].strip()[1:-1]
-            self.logger.info(node_type == 'router')
+            node_type = self.r2.wpanctl("get", "get " + wpan.WPAN_NODE_TYPE, 2).split("=")[1].strip()[1:-1]
+            self.logger.info(node_type == "router")
 
-            if node_type == 'router':
-                self.logger.info('Matched!!!!!!!!!!!!!')
+            if node_type == "router":
+                self.logger.info("Matched!!!!!!!!!!!!!")
                 break
             time.sleep(10)
         else:
-            self.assertFalse(True, 'Router cannot get into router role after 100 seconds timeout')
+            self.assertFalse(True, "Router cannot get into router role after 100 seconds timeout")
 
     @testcase.test_method_decorator
     def test02_verify_prefix(self):
-        # Add 4 prefixes(`prefix1`, 'prefix2', `prefix3` and `common_prefix`) and
+        # Add 4 prefixes(`prefix1`, `prefix2`, `prefix3` and `common_prefix`) and
         # verify they are present on all nodes with correct flags
 
         # Add a unique prefix on each node.
@@ -168,34 +166,58 @@ class TestNetworkDataTimeout(testcase.TestCase):
         sed1_rloc16 = int(self.sed1.get(wpan.WPAN_THREAD_RLOC16), 0)
 
         def check_prefixes():
-            # Verify that all three `prefix1`, 'prefix2', and `prefix3` are present on all nodes and
+            # Verify that all three `prefix1`, `prefix2`, and `prefix3` are present on all nodes and
             # are respectively associated with `r1`, r2, and `sed1` nodes.
             self.logger.info(" verify prefix1 i.e. {} added by r1 i.e. {} having rloc16:{}"
                              " is present on all nodes".format(prefix1, self.r1.name, hex(r1_rloc16)))
-            verify_prefix_with_rloc16([self.r1, self.r2, self.sed1], prefix1, r1_rloc16,
-                                          on_mesh=True, preferred=True, stable=True)
+            verify_prefix_with_rloc16([self.r1, self.r2, self.sed1],
+                                      prefix1,
+                                      r1_rloc16,
+                                      on_mesh=True,
+                                      preferred=True,
+                                      stable=True)
             self.logger.info(" verify prefix2 i.e. {} added by r2 i.e. {} having rloc16:{}"
                              " is present on all nodes".format(prefix2, self.r2.name, hex(r2_rloc16)))
-            verify_prefix_with_rloc16([self.r1, self.r2, self.sed1], prefix2, r2_rloc16,
-                                          on_mesh=True, preferred=True, stable=True, )
+            verify_prefix_with_rloc16([self.r1, self.r2, self.sed1],
+                                      prefix2,
+                                      r2_rloc16,
+                                      on_mesh=True,
+                                      preferred=True,
+                                      stable=True)
             self.logger.info(" verify prefix3 i.e. {} added by sed1 i.e.{} having rloc16:{}"
                              " is present on all nodes".format(prefix3, self.sed1.name, hex(sed1_rloc16)))
-            verify_prefix_with_rloc16([self.r1, self.r2, self.sed1], prefix3, sed1_rloc16,
-                                          on_mesh=True, preferred=True, stable=True, )
+            verify_prefix_with_rloc16([self.r1, self.r2, self.sed1],
+                                      prefix3,
+                                      sed1_rloc16,
+                                      on_mesh=True,
+                                      preferred=True,
+                                      stable=True)
 
             # Verify the presence of `common_prefix` associated with each node (with correct flags).
             self.logger.info(" verify common_prefix i.e. {} added by r1 i.e. {} having rloc16:{}"
                              " is present on all nodes".format(common_prefix, self.r1.name, hex(r1_rloc16)))
-            verify_prefix_with_rloc16([self.r1, self.r2, self.sed1], common_prefix, r1_rloc16,
-                                          on_mesh=True, preferred=True, stable=False,)
+            verify_prefix_with_rloc16([self.r1, self.r2, self.sed1],
+                                      common_prefix,
+                                      r1_rloc16,
+                                      on_mesh=True,
+                                      preferred=True,
+                                      stable=False)
             self.logger.info(" verify common_prefix i.e. {} added by r2 i.e. {} having rloc16:{}"
                              " is present on all nodes".format(common_prefix, self.r2.name, hex(r2_rloc16)))
-            verify_prefix_with_rloc16([self.r1, self.r2, self.sed1], common_prefix, r2_rloc16,
-                                          on_mesh=True, preferred=True, stable=True, )
+            verify_prefix_with_rloc16([self.r1, self.r2, self.sed1],
+                                      common_prefix,
+                                      r2_rloc16,
+                                      on_mesh=True,
+                                      preferred=True,
+                                      stable=True)
             self.logger.info(" verify common_prefix i.e. {} added by sed1 i.e.{} having rloc16:{}"
                              " is present on all nodes".format(common_prefix, self.sed1.name, hex(sed1_rloc16)))
-            verify_prefix_with_rloc16([self.r1, self.r2, self.sed1], common_prefix, sed1_rloc16,
-                                          on_mesh=True, preferred=False, stable=True, )
+            verify_prefix_with_rloc16([self.r1, self.r2, self.sed1],
+                                      common_prefix,
+                                      sed1_rloc16,
+                                      on_mesh=True,
+                                      preferred=False,
+                                      stable=True)
 
         verify_within(check_prefixes, WAIT_TIME)
 
@@ -212,21 +234,19 @@ class TestNetworkDataTimeout(testcase.TestCase):
         self.r2.leave()
         self.wait_for_completion(self.device_list)
 
-        self.logger.info("Wait for {}s for on-mesh prefix to be updated after r2's removal"
-                         .format(PREFIX_SYNC_WAIT_AFTER_ROUTER_REMOVAL))
+        self.logger.info("Wait for {}s for on-mesh prefix to be updated after r2's removal".format(
+            PREFIX_SYNC_WAIT_AFTER_ROUTER_REMOVAL))
         time.sleep(PREFIX_SYNC_WAIT_AFTER_ROUTER_REMOVAL)
 
         def check_prefixes_on_r1_after_r2_leave():
             # Verify that entries added by r1 are still present
             self.logger.info(" verify prefix entries {} and {} added by r1 ({})"
                              "are still present".format(prefix1, common_prefix, self.r1.name))
-            verify_prefix_with_rloc16([self.r1], prefix1, r1_rloc16,
-                                          on_mesh=True, preferred=True, stable=True)
-            verify_prefix_with_rloc16([self.r1], common_prefix, r1_rloc16,
-                                          on_mesh=True, preferred=True, stable=False,)
+            verify_prefix_with_rloc16([self.r1], prefix1, r1_rloc16, on_mesh=True, preferred=True, stable=True)
+            verify_prefix_with_rloc16([self.r1], common_prefix, r1_rloc16, on_mesh=True, preferred=True, stable=False)
 
-            self.logger.info(" verify prefix entries {}, {}, {} added by `r2` {} or `sed1` {} are removed"
-                             .format(prefix2, prefix3, common_prefix, self.r2.name, self.sed1.name))
+            self.logger.info(" verify prefix entries {}, {}, {} added by `r2` {} or `sed1` {} are removed".format(
+                prefix2, prefix3, common_prefix, self.r2.name, self.sed1.name))
             verify_no_prefix_with_rloc16([self.r1], prefix2, r2_rloc16)
             verify_no_prefix_with_rloc16([self.r1], prefix3, sed1_rloc16)
             verify_no_prefix_with_rloc16([self.r1], common_prefix, r2_rloc16)

--- a/silk/tests/openthread/ot_test_on_mesh_prefix_config_gateway.py
+++ b/silk/tests/openthread/ot_test_on_mesh_prefix_config_gateway.py
@@ -12,33 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import range
-from silk.config import wpan_constants as wpan
-import silk.node.fifteen_four_dev_board as ffdb
-from silk.node.wpan_node import WpanCredentials
-import silk.hw.hw_resource as hwr
-import silk.tests.testcase as testcase
-from silk.utils import process_cleanup
-
-from silk.tools.wpan_util import verify_address, verify_prefix, is_associated, verify
-
 import random
 import unittest
 import time
 
+from silk.config import wpan_constants as wpan
+from silk.node.wpan_node import WpanCredentials
+from silk.tools.wpan_util import verify_address, verify_prefix, is_associated, verify
+from silk.utils import process_cleanup
+import silk.hw.hw_resource as hwr
+import silk.node.fifteen_four_dev_board as ffdb
+import silk.tests.testcase as testcase
+
 hwr.global_instance()
 
-prefix1 = 'fd00:abba:cafe::'
-prefix2 = 'fd00:1234::'
-prefix3 = 'fd00:deed::'
-prefix4 = 'fd00:abcd::'
+prefix1 = "fd00:abba:cafe::"
+prefix2 = "fd00:1234::"
+prefix3 = "fd00:deed::"
+prefix4 = "fd00:abcd::"
 
 
 class TestOnMeshPrefixConfigGateway(testcase.TestCase):
     poll_interval = 200
 
     @classmethod
-    def hardwareSelect(cls):
+    def hardware_select(cls):
         cls.r1 = ffdb.ThreadDevBoard()
         cls.r2 = ffdb.ThreadDevBoard()
         cls.sc1 = ffdb.ThreadDevBoard()
@@ -52,7 +50,7 @@ class TestOnMeshPrefixConfigGateway(testcase.TestCase):
         # Check and clean up wpantund process if any left over
         process_cleanup.ps_cleanup()
 
-        cls.hardwareSelect()
+        cls.hardware_select()
 
         for device in cls.all_nodes:
 
@@ -61,11 +59,10 @@ class TestOnMeshPrefixConfigGateway(testcase.TestCase):
 
             device.set_up()
 
-        cls.network_data = WpanCredentials(
-            network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
-            psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
-            channel=random.randint(11, 25),
-            fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
+        cls.network_data = WpanCredentials(network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
+                                           psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
+                                           channel=random.randint(11, 25),
+                                           fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
 
         cls.thread_sniffer_init(cls.network_data.channel)
 
@@ -101,7 +98,7 @@ class TestOnMeshPrefixConfigGateway(testcase.TestCase):
         self.network_data.xpanid = self.r1.xpanid
         self.network_data.panid = self.r1.panid
 
-        self.r2.join(self.network_data, 'router')
+        self.r2.join(self.network_data, "router")
         self.wait_for_completion(self.device_list)
 
         self.sc1.join(self.network_data, "sleepy-end-device")
@@ -113,15 +110,15 @@ class TestOnMeshPrefixConfigGateway(testcase.TestCase):
         self.sc2.set_sleep_poll_interval(self.poll_interval)
 
         for _ in range(18):
-            node_type = self.r2.wpanctl('get', 'get '+wpan.WPAN_NODE_TYPE, 2).split('=')[1].strip()[1:-1]
-            print(node_type == 'router')
+            node_type = self.r2.wpanctl("get", "get " + wpan.WPAN_NODE_TYPE, 2).split("=")[1].strip()[1:-1]
+            print(node_type == "router")
 
-            if node_type == 'router':
-                print('Matched!!!!!!!!!!!!!')
+            if node_type == "router":
+                print("Matched!!!!!!!!!!!!!")
                 break
             time.sleep(10)
         else:
-            self.assertFalse(True, 'Router cannot get into router role after 180 seconds timeout')
+            self.assertFalse(True, "Router cannot get into router role after 180 seconds timeout")
 
     @testcase.test_method_decorator
     def test02_Verify_Prefix(self):
@@ -135,18 +132,23 @@ class TestOnMeshPrefixConfigGateway(testcase.TestCase):
         verify_address(self.all_nodes, prefix1)
 
         # Now add prefix2 with priority `high` on router r2 and check all nodes for the new prefix/address
-        self.r2.config_gateway1(prefix2, default_route=True, priority='1')
+        self.r2.config_gateway1(prefix2, default_route=True, priority="1")
         self.wait_for_completion(self.device_list)
         time.sleep(60)
-        verify_prefix(self.all_nodes, prefix2, stable=True, on_mesh=True, slaac=True, default_route=True,
-                      priority='high')
+        verify_prefix(self.all_nodes,
+                      prefix2,
+                      stable=True,
+                      on_mesh=True,
+                      slaac=True,
+                      default_route=True,
+                      priority="high")
         verify_address(self.all_nodes, prefix2)
 
         # Add prefix3 on sleepy end-device and check for it on all nodes
-        self.sc1.config_gateway1(prefix3, priority='-1')
+        self.sc1.config_gateway1(prefix3, priority="-1")
         self.wait_for_completion(self.device_list)
         time.sleep(60)
-        verify_prefix(self.all_nodes, prefix3, stable=True, on_mesh=True, slaac=True, priority='low')
+        verify_prefix(self.all_nodes, prefix3, stable=True, on_mesh=True, slaac=True, priority="low")
         verify_address(self.all_nodes, prefix3)
 
     @testcase.test_method_decorator
@@ -161,8 +163,8 @@ class TestOnMeshPrefixConfigGateway(testcase.TestCase):
         wait_time = 5
         while not is_associated(self.r1):
             if time.time() - start_time > wait_time:
-                print('Took too long for node to recover after reset ({}>{} sec)'.format(time.time() - start_time,
-                                                                                         wait_time))
+                print("Took too long for node to recover after reset ({}>{} sec)".format(
+                    time.time() - start_time, wait_time))
                 exit(1)
             time.sleep(0.25)
 
@@ -175,38 +177,57 @@ class TestOnMeshPrefixConfigGateway(testcase.TestCase):
     def test04_Verify_Add_Remove_Prefix(self):
         # Test `add-prefix` and `remove-prefix`
 
-        self.r1.add_prefix(prefix4, 48, priority="1", stable=False, on_mesh=True, slaac=False, dhcp=True,
-                           configure=False, default_route=True, preferred=False)
+        self.r1.add_prefix(prefix4,
+                           48,
+                           priority="1",
+                           stable=False,
+                           on_mesh=True,
+                           slaac=False,
+                           dhcp=True,
+                           configure=False,
+                           default_route=True,
+                           preferred=False)
 
-        verify_prefix([self.r1], prefix4, 48, priority="high", stable=False, on_mesh=True, slaac=False, dhcp=True,
-                      configure=False, default_route=True, preferred=False)
+        verify_prefix([self.r1],
+                      prefix4,
+                      48,
+                      priority="high",
+                      stable=False,
+                      on_mesh=True,
+                      slaac=False,
+                      dhcp=True,
+                      configure=False,
+                      default_route=True,
+                      preferred=False)
 
         # Remove prefix and verify that it is removed from list
         self.r1.remove_prefix(prefix4, 48)
         time.sleep(0.5)
         verify(self.r1.get(wpan.WPAN_THREAD_ON_MESH_PREFIXES).find(prefix4) < 0)
 
-        self.r1.add_prefix(prefix4, 48, priority="-1", stable=True, on_mesh=False, slaac=True, dhcp=False,
-                           configure=True, default_route=False, preferred=True)
+        self.r1.add_prefix(prefix4,
+                           48,
+                           priority="-1",
+                           stable=True,
+                           on_mesh=False,
+                           slaac=True,
+                           dhcp=False,
+                           configure=True,
+                           default_route=False,
+                           preferred=True)
 
-        verify_prefix([self.r1], prefix4, 48, priority="low", stable=True, on_mesh=False, slaac=True, dhcp=False,
-                      configure=True, default_route=False, preferred=True)
+        verify_prefix([self.r1],
+                      prefix4,
+                      48,
+                      priority="low",
+                      stable=True,
+                      on_mesh=False,
+                      slaac=True,
+                      dhcp=False,
+                      configure=True,
+                      default_route=False,
+                      preferred=True)
 
 
 if __name__ == "__main__":
     unittest.main()
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/silk/tests/openthread/ot_test_parent_reset_child_recovery.py
+++ b/silk/tests/openthread/ot_test_parent_reset_child_recovery.py
@@ -12,18 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import range
-from silk.config import wpan_constants as wpan
-import silk.node.fifteen_four_dev_board as ffdb
-from silk.node.wpan_node import WpanCredentials
-from silk.tools import wpan_table_parser
-import silk.hw.hw_resource as hwr
-import silk.tests.testcase as testcase
-from silk.tools.wpan_util import verify, verify_within, is_associated
-from silk.utils import process_cleanup
-
 import random
 import unittest
+
+from silk.config import wpan_constants as wpan
+from silk.node.wpan_node import WpanCredentials
+from silk.tools import wpan_table_parser
+from silk.tools.wpan_util import verify, verify_within, is_associated
+from silk.utils import process_cleanup
+import silk.hw.hw_resource as hwr
+import silk.node.fifteen_four_dev_board as ffdb
+import silk.tests.testcase as testcase
 
 hwr.global_instance()
 
@@ -37,7 +36,7 @@ class TestParentResetChildRecovery(testcase.TestCase):
     poll_interval = 4000
 
     @classmethod
-    def hardwareSelect(cls):
+    def hardware_select(cls):
         cls.router = ffdb.ThreadDevBoard()
 
         cls.sleepy_children = []
@@ -57,7 +56,7 @@ class TestParentResetChildRecovery(testcase.TestCase):
         # Check and clean up wpantund process if any left over
         process_cleanup.ps_cleanup()
 
-        cls.hardwareSelect()
+        cls.hardware_select()
 
         cls.add_test_device(cls.router)
 
@@ -68,11 +67,10 @@ class TestParentResetChildRecovery(testcase.TestCase):
             device.set_logger(cls.logger)
             device.set_up()
 
-        cls.network_data = WpanCredentials(
-            network_name = "SILK-{0:04X}".format(random.randint(0, 0xffff)),
-            psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
-            channel=random.randint(11, 25),
-            fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
+        cls.network_data = WpanCredentials(network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
+                                           psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
+                                           channel=random.randint(11, 25),
+                                           fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
 
         cls.thread_sniffer_init(cls.network_data.channel)
 
@@ -98,8 +96,8 @@ class TestParentResetChildRecovery(testcase.TestCase):
 
     @testcase.test_method_decorator
     def test01_Pairing(self):
-        self.router.form(self.network_data, 'router')
-        self.router.permit_join(60*NUM_CHILDREN)
+        self.router.form(self.network_data, "router")
+        self.router.permit_join(60 * NUM_CHILDREN)
         self.wait_for_completion(self.device_list)
 
         self.logger.info(self.router.ip6_lla)
@@ -148,7 +146,8 @@ class TestParentResetChildRecovery(testcase.TestCase):
 
         # Verify that number of state changes on all children stays as before (indicating they did not get detached).
         for i in range(len(self.all_children)):
-            verify(child_num_state_changes[i] == len(wpan_table_parser.parse_list(self.all_children[i].get("stat:ncp"))))
+            verify(
+                child_num_state_changes[i] == len(wpan_table_parser.parse_list(self.all_children[i].get("stat:ncp"))))
 
 
 if __name__ == "__main__":

--- a/silk/tests/openthread/ot_test_partition_merge.py
+++ b/silk/tests/openthread/ot_test_partition_merge.py
@@ -12,32 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import range
-from silk.config import wpan_constants as wpan
-from silk.tools.wpan_util import verify
-from silk.tools import wpan_table_parser
-
-import silk.node.fifteen_four_dev_board as ffdb
-from silk.node.wpan_node import WpanCredentials
-import silk.hw.hw_resource as hwr
-import silk.tests.testcase as testcase
-from silk.utils import process_cleanup
-
-from silk.tools.wpan_util import verify_address, verify_prefix
-
 import random
 import unittest
 import time
 
+from silk.config import wpan_constants as wpan
+from silk.node.wpan_node import WpanCredentials
+from silk.tools import wpan_table_parser
+from silk.tools.wpan_util import verify
+from silk.tools.wpan_util import verify_address, verify_prefix
+from silk.utils import process_cleanup
+import silk.hw.hw_resource as hwr
+import silk.node.fifteen_four_dev_board as ffdb
+import silk.tests.testcase as testcase
+
 hwr.global_instance()
 
-prefix1 = 'fd00:abba:cafe::'
-prefix2 = 'fd00:1234::'
+prefix1 = "fd00:abba:cafe::"
+prefix2 = "fd00:1234::"
 NUM_CHILDREN = 1
 
 
 class TestPartitionMerge(testcase.TestCase):
-    # -----------------------------------------------------------------------------------------------------------------------
     # Test description: Partition formation and merge
     #
     # Network Topology:
@@ -56,7 +52,7 @@ class TestPartitionMerge(testcase.TestCase):
     #   merge the info in combined.
 
     @classmethod
-    def hardwareSelect(cls):
+    def hardware_select(cls):
         cls.r1 = ffdb.ThreadDevBoard()
         cls.r2 = ffdb.ThreadDevBoard()
         cls.fed1 = ffdb.ThreadDevBoard()
@@ -71,7 +67,7 @@ class TestPartitionMerge(testcase.TestCase):
         # Check and clean up wpantund process if any left over
         process_cleanup.ps_cleanup()
 
-        cls.hardwareSelect()
+        cls.hardware_select()
 
         for device in cls.all_nodes:
 
@@ -80,12 +76,10 @@ class TestPartitionMerge(testcase.TestCase):
 
             device.set_up()
 
-        cls.network_data = WpanCredentials(
-            network_name="MORTAR-{0:04X}".format(random.randint(0, 0xffff)),
-            psk="00112233445566778899aabbccdd{0:04x}".
-                format(random.randint(0, 0xffff)),
-            channel=random.randint(11, 25),
-            fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
+        cls.network_data = WpanCredentials(network_name="MORTAR-{0:04X}".format(random.randint(0, 0xffff)),
+                                           psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
+                                           channel=random.randint(11, 25),
+                                           fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
 
         cls.thread_sniffer_init(cls.network_data.channel)
 
@@ -112,8 +106,9 @@ class TestPartitionMerge(testcase.TestCase):
             raise RuntimeError("device name is not used in this function")
 
         for _ in range(18):
-            node_type = device.wpanctl('get', 'get '+wpan.WPAN_NODE_TYPE, 2).split('=')[1].strip()[1:-1]
-            self.logger.info('Node type for {} is {} currently, expect to be {}'.format(device_name, node_type, expect_role))
+            node_type = device.wpanctl("get", "get " + wpan.WPAN_NODE_TYPE, 2).split("=")[1].strip()[1:-1]
+            self.logger.info("Node type for {} is {} currently, expect to be {}".format(
+                device_name, node_type, expect_role))
 
             if node_type == expect_role:
                 return True
@@ -142,7 +137,7 @@ class TestPartitionMerge(testcase.TestCase):
         self.network_data.xpanid = self.r1.xpanid
         self.network_data.panid = self.r1.panid
 
-        self.r2.join(self.network_data, 'router')
+        self.r2.join(self.network_data, "router")
         self.wait_for_completion(self.device_list)
 
         self.fed1.join(self.network_data, "end-node")
@@ -153,43 +148,47 @@ class TestPartitionMerge(testcase.TestCase):
 
         # verify r1 role is leader
         r1_result = self._verify_device_role("r1", "leader")
-        self.assertTrue(r1_result, 'r1 cannot get into leader role after 180 seconds timeout')
+        self.assertTrue(r1_result, "r1 cannot get into leader role after 180 seconds timeout")
 
         # verify r2 role is router
         r2_result = self._verify_device_role("r2", "router")
-        self.assertTrue(r2_result, 'r2 cannot get into router role after 180 seconds timeout')
+        self.assertTrue(r2_result, "r2 cannot get into router role after 180 seconds timeout")
 
     @testcase.test_method_decorator
     def test02_unwhitelist_r1_r2(self):
         """
-        un_whitelist r1 and r2, verify r2 become leader
-        """
+    un_whitelist r1 and r2, verify r2 become leader
+    """
         self.r1.un_whitelist_node(self.r2)
         self.r2.un_whitelist_node(self.r1)
 
         # verify r2 become leader
         r2_result = self._verify_device_role("r2", "leader")
-        self.assertTrue(r2_result, 'r2 cannot get into leader role after 180 seconds timeout')
+        self.assertTrue(r2_result, "r2 cannot get into leader role after 180 seconds timeout")
 
         # verify r1 become leader
         r1_result = self._verify_device_role("r1", "leader")
-        self.assertTrue(r1_result, 'r1 cannot get into leader role after 180 seconds timeout')
+        self.assertTrue(r1_result, "r1 cannot get into leader role after 180 seconds timeout")
 
         # Now add prefix2 with priority `high` on router r2 and check r2&fed2 nodes for the new prefix/address
-        self.r2.config_gateway1(prefix2, default_route=True, priority='1')
+        self.r2.config_gateway1(prefix2, default_route=True, priority="1")
         self.wait_for_completion(self.device_list)
         time.sleep(60)
         r2_network_nodes = [self.r2, self.fed2]
-        verify_prefix(r2_network_nodes, prefix2, stable=True, on_mesh=True, slaac=True, default_route=True,
-                      priority='high')
+        verify_prefix(r2_network_nodes,
+                      prefix2,
+                      stable=True,
+                      on_mesh=True,
+                      slaac=True,
+                      default_route=True,
+                      priority="high")
         verify_address(r2_network_nodes, prefix2)
 
         # verify r1, r2 has different partition
-        r1_partition = self.r1.wpanctl('get', 'get ' + wpan.WPAN_PARTITION_ID, 2).split('=')[1].strip()[1:-1]
-        r2_partition = self.r2.wpanctl('get', 'get ' + wpan.WPAN_PARTITION_ID, 2).split('=')[1].strip()[1:-1]
-        self.logger.info(
-            'r1 partition is {}, r2 partition is {}'.format(r1_partition, r2_partition))
-        self.assertFalse(r1_partition == r2_partition, 'r1, r2 partition id are same after unwhite list r1, r2')
+        r1_partition = self.r1.wpanctl("get", "get " + wpan.WPAN_PARTITION_ID, 2).split("=")[1].strip()[1:-1]
+        r2_partition = self.r2.wpanctl("get", "get " + wpan.WPAN_PARTITION_ID, 2).split("=")[1].strip()[1:-1]
+        self.logger.info("r1 partition is {}, r2 partition is {}".format(r1_partition, r2_partition))
+        self.assertFalse(r1_partition == r2_partition, "r1, r2 partition id are same after unwhite list r1, r2")
 
     @testcase.test_method_decorator
     def test03_whitelist_r1_r2(self):
@@ -207,11 +206,10 @@ class TestPartitionMerge(testcase.TestCase):
         time.sleep(60)
 
         # verify partition id match
-        r1_partition = self.r1.wpanctl('get', 'get ' + wpan.WPAN_PARTITION_ID, 2).split('=')[1].strip()[1:-1]
-        r2_partition = self.r2.wpanctl('get', 'get ' + wpan.WPAN_PARTITION_ID, 2).split('=')[1].strip()[1:-1]
-        self.logger.info(
-            'r1 partition is {}, r2 partition is {}'.format(r1_partition, r2_partition))
-        self.assertTrue(r1_partition == r2_partition, 'r1, r2 partition id are not same after white list r1, r2')
+        r1_partition = self.r1.wpanctl("get", "get " + wpan.WPAN_PARTITION_ID, 2).split("=")[1].strip()[1:-1]
+        r2_partition = self.r2.wpanctl("get", "get " + wpan.WPAN_PARTITION_ID, 2).split("=")[1].strip()[1:-1]
+        self.logger.info("r1 partition is {}, r2 partition is {}".format(r1_partition, r2_partition))
+        self.assertTrue(r1_partition == r2_partition, "r1, r2 partition id are not same after white list r1, r2")
 
     @testcase.test_method_decorator
     def test04_verify_role_prefix_childTable(self):
@@ -219,15 +217,20 @@ class TestPartitionMerge(testcase.TestCase):
         verify_prefix(self.all_nodes, prefix1, stable=True, on_mesh=True, slaac=True)
         verify_address(self.all_nodes, prefix1)
         # Verify that the prefix1 and its corresponding address are present on all nodes
-        verify_prefix(self.all_nodes, prefix2, stable=True, on_mesh=True, slaac=True,
-                      default_route=True, priority='high')
+        verify_prefix(self.all_nodes,
+                      prefix2,
+                      stable=True,
+                      on_mesh=True,
+                      slaac=True,
+                      default_route=True,
+                      priority="high")
         verify_address(self.all_nodes, prefix2)
 
         # verify r1, r2 role, one of them is leader
-        r1_role = self.r1.wpanctl('get', 'get ' + wpan.WPAN_NODE_TYPE, 2).split('=')[1].strip()[1:-1]
-        r2_role = self.r2.wpanctl('get', 'get ' + wpan.WPAN_NODE_TYPE, 2).split('=')[1].strip()[1:-1]
-        roles_result = (r1_role=="leader" and r2_role=="router") or (r2_role=="leader" and r1_role=="router")
-        self.assertTrue(roles_result, 'r1, r2 role is not right, r1 is {}, r2 is {}'.format(r1_role, r2_role))
+        r1_role = self.r1.wpanctl("get", "get " + wpan.WPAN_NODE_TYPE, 2).split("=")[1].strip()[1:-1]
+        r2_role = self.r2.wpanctl("get", "get " + wpan.WPAN_NODE_TYPE, 2).split("=")[1].strip()[1:-1]
+        roles_result = (r1_role == "leader" and r2_role == "router") or (r2_role == "leader" and r1_role == "router")
+        self.assertTrue(roles_result, "r1, r2 role is not right, r1 is {}, r2 is {}".format(r1_role, r2_role))
 
         # verify their children stayed with their parents
         childTable = self.r1.wpanctl("get", "get " + wpan.WPAN_THREAD_CHILD_TABLE, 2)

--- a/silk/tests/openthread/ot_test_permit_join.py
+++ b/silk/tests/openthread/ot_test_permit_join.py
@@ -12,16 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import silk.node.fifteen_four_dev_board as ffdb
-from silk.node.wpan_node import WpanCredentials
-import silk.hw.hw_resource as hwr
-import silk.tests.testcase as testcase
-from silk.config import wpan_constants as wpan
-from silk.utils import process_cleanup
-
 import random
-import unittest
 import time
+import unittest
+
+from silk.config import wpan_constants as wpan
+from silk.node.wpan_node import WpanCredentials
+from silk.utils import process_cleanup
+import silk.hw.hw_resource as hwr
+import silk.node.fifteen_four_dev_board as ffdb
+import silk.tests.testcase as testcase
 
 hwr.global_instance()
 
@@ -29,7 +29,7 @@ hwr.global_instance()
 class TestPermitJoin(testcase.TestCase):
 
     @classmethod
-    def hardwareSelect(cls):
+    def hardware_select(cls):
         cls.router = ffdb.ThreadDevBoard()
 
     @classmethod
@@ -38,7 +38,7 @@ class TestPermitJoin(testcase.TestCase):
         # Check and clean up wpantund process if any left over
         process_cleanup.ps_cleanup()
 
-        cls.hardwareSelect()
+        cls.hardware_select()
 
         cls.add_test_device(cls.router)
 
@@ -46,11 +46,10 @@ class TestPermitJoin(testcase.TestCase):
             device.set_logger(cls.logger)
             device.set_up()
 
-        cls.network_data = WpanCredentials(
-            network_name = "SILK-{0:04X}".format(random.randint(0, 0xffff)),
-            psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
-            channel=random.randint(11, 25),
-            fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
+        cls.network_data = WpanCredentials(network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
+                                           psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
+                                           channel=random.randint(11, 25),
+                                           fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
 
     @classmethod
     @testcase.teardown_class_decorator
@@ -68,33 +67,33 @@ class TestPermitJoin(testcase.TestCase):
 
     @testcase.test_method_decorator
     def test01_Form_Network(self):
-        self.router.form(self.network_data, 'router')
+        self.router.form(self.network_data, "router")
         self.wait_for_completion(self.device_list)
 
-        self.assertEqual(self.router.getprop(wpan.WPAN_NETWORK_ALLOW_JOIN), 'false')
+        self.assertEqual(self.router.getprop(wpan.WPAN_NETWORK_ALLOW_JOIN), "false")
 
     @testcase.test_method_decorator
     def test02_Permit_Join_enable(self):
         self.router.permit_join_new()
-        self.assertEqual(self.router.getprop(wpan.WPAN_NETWORK_ALLOW_JOIN), 'true')
+        self.assertEqual(self.router.getprop(wpan.WPAN_NETWORK_ALLOW_JOIN), "true")
 
-        self.router.permit_join_new('0')
-        self.assertEqual(self.router.getprop(wpan.WPAN_NETWORK_ALLOW_JOIN), 'false')
+        self.router.permit_join_new("0")
+        self.assertEqual(self.router.getprop(wpan.WPAN_NETWORK_ALLOW_JOIN), "false")
 
-        self.router.permit_join_new(port='1234')
-        self.assertEqual(self.router.getprop(wpan.WPAN_NETWORK_ALLOW_JOIN), 'true')
+        self.router.permit_join_new(port="1234")
+        self.assertEqual(self.router.getprop(wpan.WPAN_NETWORK_ALLOW_JOIN), "true")
 
-        self.router.permit_join_new('0')
-        self.assertEqual(self.router.getprop(wpan.WPAN_NETWORK_ALLOW_JOIN), 'false')
+        self.router.permit_join_new("0")
+        self.assertEqual(self.router.getprop(wpan.WPAN_NETWORK_ALLOW_JOIN), "false")
 
     @testcase.test_method_decorator
     def test03_Permit_Join_time(self):
-        self.router.permit_join_new('10')
-        self.assertEqual(self.router.getprop(wpan.WPAN_NETWORK_ALLOW_JOIN), 'true')
+        self.router.permit_join_new("10")
+        self.assertEqual(self.router.getprop(wpan.WPAN_NETWORK_ALLOW_JOIN), "true")
 
         time.sleep(11)
 
-        self.assertEqual(self.router.getprop(wpan.WPAN_NETWORK_ALLOW_JOIN), 'false')
+        self.assertEqual(self.router.getprop(wpan.WPAN_NETWORK_ALLOW_JOIN), "false")
 
 
 if __name__ == "__main__":

--- a/silk/tests/openthread/ot_test_router_table.py
+++ b/silk/tests/openthread/ot_test_router_table.py
@@ -12,19 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import range
-from silk.config import wpan_constants as wpan
-import silk.node.fifteen_four_dev_board as ffdb
-from silk.node.wpan_node import WpanCredentials
-from silk.tools import wpan_table_parser
-import silk.hw.hw_resource as hwr
-import silk.tests.testcase as testcase
-from silk.tools.wpan_util import verify, VerifyError, verify_within
-from silk.utils import process_cleanup
-
 import random
 import unittest
 import time
+
+from silk.config import wpan_constants as wpan
+from silk.node.wpan_node import WpanCredentials
+from silk.tools import wpan_table_parser
+from silk.tools.wpan_util import verify, VerifyError, verify_within
+from silk.utils import process_cleanup
+import silk.hw.hw_resource as hwr
+import silk.node.fifteen_four_dev_board as ffdb
+import silk.tests.testcase as testcase
+
 hwr.global_instance()
 
 WAIT_TIME = 30
@@ -44,7 +44,7 @@ class TestRouterTable(testcase.TestCase):
     #                    c1
 
     @classmethod
-    def hardwareSelect(cls):
+    def hardware_select(cls):
         cls.r1 = ffdb.ThreadDevBoard()
         cls.r2 = ffdb.ThreadDevBoard()
         cls.r3 = ffdb.ThreadDevBoard()
@@ -57,7 +57,7 @@ class TestRouterTable(testcase.TestCase):
         # Check and clean up wpantund process if any left over
         process_cleanup.ps_cleanup()
 
-        cls.hardwareSelect()
+        cls.hardware_select()
 
         for device in (cls.r1, cls.r2, cls.r3, cls.r4, cls.c1):
             cls.add_test_device(device)
@@ -66,12 +66,10 @@ class TestRouterTable(testcase.TestCase):
             device.set_logger(cls.logger)
             device.set_up()
 
-        cls.network_data = WpanCredentials(
-            network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
-            psk="00112233445566778899aabbccdd{0:04x}".
-                format(random.randint(0, 0xffff)),
-            channel=random.randint(11, 25),
-            fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
+        cls.network_data = WpanCredentials(network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
+                                           psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
+                                           channel=random.randint(11, 25),
+                                           fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
 
         cls.thread_sniffer_init(cls.network_data.channel)
 
@@ -92,7 +90,7 @@ class TestRouterTable(testcase.TestCase):
     @testcase.test_method_decorator
     def test01_Form_Network(self):
         # Form the Network
-        self.r1.form(self.network_data, 'router')
+        self.r1.form(self.network_data, "router")
         self.wait_for_completion(self.device_list)
 
         # whitelist all routers with each other
@@ -119,27 +117,27 @@ class TestRouterTable(testcase.TestCase):
         self.network_data.panid = self.r1.panid
 
         for router in (self.r2, self.r3, self.r4):
-            router.join(self.network_data, 'router')
+            router.join(self.network_data, "router")
             self.wait_for_completion(self.device_list)
 
-        self.c1.join(self.network_data, 'sleepy-end-device')
+        self.c1.join(self.network_data, "sleepy-end-device")
         self.wait_for_completion(self.device_list)
         self.c1.set_sleep_poll_interval(2000)
 
         for _ in range(30):
-            r2_node_type = self.r2.wpanctl('get', 'get '+wpan.WPAN_NODE_TYPE, 2).split('=')[1].strip()[1:-1]
-            r3_node_type = self.r3.wpanctl('get', 'get ' + wpan.WPAN_NODE_TYPE, 2).split('=')[1].strip()[1:-1]
-            r4_node_type = self.r4.wpanctl('get', 'get ' + wpan.WPAN_NODE_TYPE, 2).split('=')[1].strip()[1:-1]
+            r2_node_type = self.r2.wpanctl("get", "get " + wpan.WPAN_NODE_TYPE, 2).split("=")[1].strip()[1:-1]
+            r3_node_type = self.r3.wpanctl("get", "get " + wpan.WPAN_NODE_TYPE, 2).split("=")[1].strip()[1:-1]
+            r4_node_type = self.r4.wpanctl("get", "get " + wpan.WPAN_NODE_TYPE, 2).split("=")[1].strip()[1:-1]
 
             for e in (r2_node_type, r3_node_type, r4_node_type):
                 print(e)
 
-            if all(e == 'router' for e in (r2_node_type, r3_node_type, r4_node_type)):
-                print('All End-node moved up to  Router.')
+            if all(e == "router" for e in (r2_node_type, r3_node_type, r4_node_type)):
+                print("All End-node moved up to  Router.")
                 break
             time.sleep(5)
         else:
-            self.assertFalse(True, 'Router cannot get into router role after 150 seconds timeout')
+            self.assertFalse(True, "Router cannot get into router role after 150 seconds timeout")
 
     @testcase.test_method_decorator
     def test02_Verify_Node_Type(self):

--- a/silk/tests/openthread/ot_test_same_prefix_on_multiple_nodes.py
+++ b/silk/tests/openthread/ot_test_same_prefix_on_multiple_nodes.py
@@ -12,21 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import range
-from silk.config import wpan_constants as wpan
-from silk.tools.wpan_util import verify, verify_within
-from silk.tools import wpan_util
-from silk.tools import wpan_table_parser
-
-import silk.node.fifteen_four_dev_board as ffdb
-from silk.node.wpan_node import WpanCredentials
-import silk.hw.hw_resource as hwr
-import silk.tests.testcase as testcase
-from silk.utils import process_cleanup
-
 import random
 import unittest
 import time
+
+from silk.config import wpan_constants as wpan
+from silk.node.wpan_node import WpanCredentials
+from silk.tools import wpan_table_parser
+from silk.tools import wpan_util
+from silk.tools.wpan_util import verify, verify_within
+from silk.utils import process_cleanup
+import silk.hw.hw_resource as hwr
+import silk.node.fifteen_four_dev_board as ffdb
+import silk.tests.testcase as testcase
 
 hwr.global_instance()
 
@@ -40,7 +38,7 @@ class TestSamePrefixonMultipleNodes(testcase.TestCase):
     poll_interval = 500
 
     @classmethod
-    def hardwareSelect(cls):
+    def hardware_select(cls):
         cls.r1 = ffdb.ThreadDevBoard()
         cls.r2 = ffdb.ThreadDevBoard()
         cls.sed2 = ffdb.ThreadDevBoard()
@@ -53,18 +51,17 @@ class TestSamePrefixonMultipleNodes(testcase.TestCase):
         # Check and clean up wpantund process if any left over
         process_cleanup.ps_cleanup()
 
-        cls.hardwareSelect()
+        cls.hardware_select()
 
         for device in cls.all_nodes:
             device.set_logger(cls.logger)
             cls.add_test_device(device)
             device.set_up()
 
-        cls.network_data = WpanCredentials(
-            network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
-            psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
-            channel=random.randint(11, 25),
-            fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
+        cls.network_data = WpanCredentials(network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
+                                           psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
+                                           channel=random.randint(11, 25),
+                                           fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
 
         cls.thread_sniffer_init(cls.network_data.channel)
 
@@ -87,12 +84,12 @@ class TestSamePrefixonMultipleNodes(testcase.TestCase):
             prefixes = wpan_table_parser.parse_on_mesh_prefix_result(node.get(wpan.WPAN_THREAD_ON_MESH_PREFIXES))
             for p in prefixes:
                 if p.prefix == IP6_PREFIX:
-                    if (p.origin == 'ncp' and p.prefix_len == '64' and p.is_stable() and p.is_on_mesh()
-                       and p.is_preferred() and not p.is_def_route() and not p.is_slaac() and not p.is_dhcp()
-                       and not p.is_config() and p.priority == "med"):
+                    if (p.origin == "ncp" and p.prefix_len == "64" and p.is_stable() and p.is_on_mesh() and
+                            p.is_preferred() and not p.is_def_route() and not p.is_slaac() and not p.is_dhcp() and
+                            not p.is_config() and p.priority == "med"):
                         break
             else:  # `for` loop finished without finding the prefix.
-                raise wpan_util.VerifyError('Did not find prefix {} on node {}'.format(IP6_PREFIX, self.r1))
+                raise wpan_util.VerifyError("Did not find prefix {} on node {}".format(IP6_PREFIX, self.r1))
 
     @testcase.test_method_decorator
     def test01_Pairing(self):
@@ -113,7 +110,7 @@ class TestSamePrefixonMultipleNodes(testcase.TestCase):
         self.network_data.xpanid = self.r1.xpanid
         self.network_data.panid = self.r1.panid
 
-        self.r2.join(self.network_data, 'router')
+        self.r2.join(self.network_data, "router")
         self.wait_for_completion(self.device_list)
 
         self.sed2.join(self.network_data, "sleepy-end-device")
@@ -121,15 +118,15 @@ class TestSamePrefixonMultipleNodes(testcase.TestCase):
         self.sed2.set_sleep_poll_interval(self.poll_interval)
 
         for _ in range(12):
-            node_type = self.r2.wpanctl('get', 'get '+wpan.WPAN_NODE_TYPE, 2).split('=')[1].strip()[1:-1]
-            print(node_type == 'router')
+            node_type = self.r2.wpanctl("get", "get " + wpan.WPAN_NODE_TYPE, 2).split("=")[1].strip()[1:-1]
+            print(node_type == "router")
 
-            if node_type == 'router':
-                print('End-node moved up to a Router.')
+            if node_type == "router":
+                print("End-node moved up to a Router.")
                 break
             time.sleep(5)
         else:
-            self.assertFalse(True, 'Router cannot get into router role after 60 seconds timeout')
+            self.assertFalse(True, "Router cannot get into router role after 60 seconds timeout")
 
     @testcase.test_method_decorator
     def test02_Verify_Add_IPV6(self):

--- a/silk/tests/openthread/ot_test_scan.py
+++ b/silk/tests/openthread/ot_test_scan.py
@@ -12,18 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import range
-import silk.node.fifteen_four_dev_board as ffdb
-from silk.node.wpan_node import WpanCredentials
-import silk.hw.hw_resource as hwr
-import silk.tests.testcase as testcase
-from silk.tools import wpan_table_parser
-from silk.config import wpan_constants as wpan
-from silk.utils import process_cleanup
-
 import random
-import unittest
 import time
+import unittest
+
+from silk.config import wpan_constants as wpan
+from silk.node.wpan_node import WpanCredentials
+from silk.tools import wpan_table_parser
+from silk.utils import process_cleanup
+import silk.hw.hw_resource as hwr
+import silk.node.fifteen_four_dev_board as ffdb
+import silk.tests.testcase as testcase
 
 hwr.global_instance()
 
@@ -34,7 +33,7 @@ class TestScan(testcase.TestCase):
     poll_interval = 1000
 
     @classmethod
-    def hardwareSelect(cls):
+    def hardware_select(cls):
         cls.scanner = ffdb.ThreadDevBoard()
 
         cls.leader_list = []
@@ -54,7 +53,7 @@ class TestScan(testcase.TestCase):
         # Check and clean up wpantund process if any left over
         process_cleanup.ps_cleanup()
 
-        cls.hardwareSelect()
+        cls.hardware_select()
 
         cls.add_test_device(cls.scanner)
 
@@ -69,12 +68,11 @@ class TestScan(testcase.TestCase):
 
         cls.network_data_list = []
         for i in range(total_networks):
-            cls.network_data_list.append(WpanCredentials(
-                network_name = "SILK-{0:04X}".format(random.randint(0, 0xffff)),
-                psk = "00112233445566778899aabbccdd{0:04x}".
-                    format(random.randint(0, 0xffff)),
-                channel = random.randint(11, 25),
-                fabric_id = "{0:06x}dead".format(random.randint(0, 0xffffff))))
+            cls.network_data_list.append(
+                WpanCredentials(network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
+                                psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
+                                channel=random.randint(11, 25),
+                                fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff))))
 
         cls.thread_sniffer_init(cls.network_data_list[0].channel)
 
@@ -97,7 +95,7 @@ class TestScan(testcase.TestCase):
         for i, device in enumerate(self.device_list):
             if i == 0:
                 continue
-            device.form(self.network_data_list[i], 'router')
+            device.form(self.network_data_list[i], "router")
             self.wait_for_completion(self.device_list)
 
         for device in self.device_list:
@@ -116,7 +114,7 @@ class TestScan(testcase.TestCase):
 
         for device in self.device_list[1:]:
             self.assertTrue(wpan_table_parser.is_in_scan_result(device, scan_result),
-                            'Device: {} is not seen in the scan result'.format(device.get(wpan.WPAN_NAME)[1:-1]))
+                            "Device: {} is not seen in the scan result".format(device.get(wpan.WPAN_NAME)[1:-1]))
 
     @testcase.test_method_decorator
     def test03_PermitJoin_Scan(self):
@@ -137,7 +135,7 @@ class TestScan(testcase.TestCase):
 
         for device in self.device_list[1:]:
             self.assertTrue(wpan_table_parser.is_in_scan_result(device, scan_result),
-                            'Device: {} is not seen in the scan result'.format(device.get(wpan.WPAN_NAME)[1:-1]))
+                            "Device: {} is not seen in the scan result".format(device.get(wpan.WPAN_NAME)[1:-1]))
 
     @testcase.test_method_decorator
     def test04_Scan_from_Associated(self):
@@ -151,7 +149,7 @@ class TestScan(testcase.TestCase):
 
         for device in self.device_list[2:]:
             self.assertTrue(wpan_table_parser.is_in_scan_result(device, scan_result),
-                            'Device: {} is not seen in the scan result'.format(device.get(wpan.WPAN_NAME)[1:-1]))
+                            "Device: {} is not seen in the scan result".format(device.get(wpan.WPAN_NAME)[1:-1]))
 
         # Scan on a specific channel
         channel = self.device_list[1].get(wpan.WPAN_CHANNEL)
@@ -165,7 +163,7 @@ class TestScan(testcase.TestCase):
 
         device = self.device_list[1]
         self.assertTrue(wpan_table_parser.is_in_scan_result(device, scan_result),
-                        'Device: {} is not seen in the scan result'.format(device.get(wpan.WPAN_NAME)[1:-1]))
+                        "Device: {} is not seen in the scan result".format(device.get(wpan.WPAN_NAME)[1:-1]))
 
     @testcase.test_method_decorator
     def test05_Discovery_Scan(self):
@@ -179,7 +177,7 @@ class TestScan(testcase.TestCase):
 
         for device in self.device_list[1:]:
             self.assertTrue(wpan_table_parser.is_in_scan_result(device, scan_result),
-                            'Device: {} is not seen in the scan result'.format(device.get(wpan.WPAN_NAME)[1:-1]))
+                            "Device: {} is not seen in the scan result".format(device.get(wpan.WPAN_NAME)[1:-1]))
 
     @testcase.test_method_decorator
     def test06_Discover_Scan_from_Associated(self):
@@ -193,7 +191,7 @@ class TestScan(testcase.TestCase):
 
         for device in self.device_list[2:]:
             self.assertTrue(wpan_table_parser.is_in_scan_result(device, scan_result),
-                            'Device: {} is not seen in the scan result'.format(device.get(wpan.WPAN_NAME)[1:-1]))
+                            "Device: {} is not seen in the scan result".format(device.get(wpan.WPAN_NAME)[1:-1]))
 
         # Scan on a specific channel
 
@@ -207,7 +205,7 @@ class TestScan(testcase.TestCase):
 
         device = self.device_list[1]
         self.assertTrue(wpan_table_parser.is_in_scan_result(device, scan_result),
-                        'Device: {} is not seen in the scan result'.format(device.get(wpan.WPAN_NAME)[1:-1]))
+                        "Device: {} is not seen in the scan result".format(device.get(wpan.WPAN_NAME)[1:-1]))
 
     #TODO add tc for energy scan, discover scan for joiner with xpanid as filter
 

--- a/silk/tests/openthread/ot_test_slaac_address_ncp.py
+++ b/silk/tests/openthread/ot_test_slaac_address_ncp.py
@@ -12,31 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from silk.config import wpan_constants as wpan
-from silk.tools.wpan_util import verify, verify_within
-from silk.tools import wpan_util
-from silk.tools import wpan_table_parser
-
-import silk.node.fifteen_four_dev_board as ffdb
-from silk.node.wpan_node import WpanCredentials
-import silk.hw.hw_resource as hwr
-import silk.tests.testcase as testcase
-from silk.utils import process_cleanup
-
 import random
-import unittest
 import time
+import unittest
+
+from silk.config import wpan_constants as wpan
+from silk.node.wpan_node import WpanCredentials
+from silk.tools import wpan_table_parser
+from silk.tools import wpan_util
+from silk.tools.wpan_util import verify, verify_within
+from silk.utils import process_cleanup
+import silk.hw.hw_resource as hwr
+import silk.node.fifteen_four_dev_board as ffdb
+import silk.tests.testcase as testcase
 
 hwr.global_instance()
 
-PREFIX = 'fd00:1234::'
+PREFIX = "fd00:1234::"
 IP_ADDRESS = PREFIX + "1234"
 
 WAIT_INTERVAL = 5
 
 
 class TestSlaacAddressNcp(testcase.TestCase):
-    # -----------------------------------------------------------------------------------------------------------------------
     # Test description: SLAAC address management by NCP
     #
     # Network topology:
@@ -64,7 +62,7 @@ class TestSlaacAddressNcp(testcase.TestCase):
     slaac_addrs = None
 
     @classmethod
-    def hardwareSelect(cls):
+    def hardware_select(cls):
         cls.r1 = ffdb.ThreadDevBoard()
         cls.r2 = ffdb.ThreadDevBoard()
         cls.fed1 = ffdb.ThreadDevBoard()
@@ -77,19 +75,17 @@ class TestSlaacAddressNcp(testcase.TestCase):
         # Check and clean up wpantund process if any left over
         process_cleanup.ps_cleanup()
 
-        cls.hardwareSelect()
+        cls.hardware_select()
 
         for device in cls.all_nodes:
             device.set_logger(cls.logger)
             cls.add_test_device(device)
             device.set_up()
 
-        cls.network_data = WpanCredentials(
-            network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
-            psk="00112233445566778899aabbccdd{0:04x}".
-                format(random.randint(0, 0xffff)),
-            channel=random.randint(11, 25),
-            fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
+        cls.network_data = WpanCredentials(network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
+                                           psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
+                                           channel=random.randint(11, 25),
+                                           fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
 
         cls.thread_sniffer_init(cls.network_data.channel)
 
@@ -108,8 +104,11 @@ class TestSlaacAddressNcp(testcase.TestCase):
         pass
 
     def check_prefix_and_slaac_address_are_added(self):
-        wpan_util.verify_correct_prefix_among_similar_prefixes(self.all_nodes, PREFIX, stable=True,
-                                                               on_mesh=True, slaac=True)
+        wpan_util.verify_correct_prefix_among_similar_prefixes(self.all_nodes,
+                                                               PREFIX,
+                                                               stable=True,
+                                                               on_mesh=True,
+                                                               slaac=True)
         wpan_util.verify_address(self.all_nodes, PREFIX)
 
     def check_prefix_and_slaac_address_are_removed(self):
@@ -138,30 +137,30 @@ class TestSlaacAddressNcp(testcase.TestCase):
         self.network_data.xpanid = self.r1.xpanid
         self.network_data.panid = self.r1.panid
 
-        self.r2.join(self.network_data, 'router')
+        self.r2.join(self.network_data, "router")
         self.wait_for_completion(self.device_list)
 
         self.fed1.join(self.network_data, "end-node")
         self.wait_for_completion(self.device_list)
 
         for _ in range(10):
-            node_type = self.r2.wpanctl('get', 'get '+wpan.WPAN_NODE_TYPE, 2).split('=')[1].strip()[1:-1]
-            self.logger.info(node_type == 'router')
+            node_type = self.r2.wpanctl("get", "get " + wpan.WPAN_NODE_TYPE, 2).split("=")[1].strip()[1:-1]
+            self.logger.info(node_type == "router")
 
-            if node_type == 'router':
-                self.logger.info('End-node moved up to a Router.')
+            if node_type == "router":
+                self.logger.info("End-node moved up to a Router.")
                 break
             time.sleep(10)
         else:
-            self.assertFalse(True, 'Router cannot get into router role after 100 seconds timeout')
+            self.assertFalse(True, "Router cannot get into router role after 100 seconds timeout")
 
     @testcase.test_method_decorator
     def test02_enable_slaac_module_on_ncp(self):
         # Enable slaac module on ncp and disable it on wpantund for all nodes and verify it is disabled.
         for node in self.all_nodes:
-            verify(node.get(wpan.WPAN_OT_SLAAC_ENABLED) == 'true')
-            node.setprop("Daemon:IPv6:AutoAddSLAACAddress", 'false')
-            verify(node.get("Daemon:IPv6:AutoAddSLAACAddress") == 'false')
+            verify(node.get(wpan.WPAN_OT_SLAAC_ENABLED) == "true")
+            node.setprop("Daemon:IPv6:AutoAddSLAACAddress", "false")
+            verify(node.get("Daemon:IPv6:AutoAddSLAACAddress") == "false")
 
     @testcase.test_method_decorator
     def test03_verify_prefix_added(self):
@@ -177,7 +176,7 @@ class TestSlaacAddressNcp(testcase.TestCase):
 
         # Save the assigned SLAAC addresses.
         TestSlaacAddressNcp.slaac_addrs = [node.find_ip6_address_with_prefix(PREFIX) for node in self.all_nodes]
-        self.logger.info('Save the assigned slaac addresses created from slaac prefix on each node')
+        self.logger.info("Save the assigned slaac addresses created from slaac prefix on each node")
         self.logger.info(self.slaac_addrs)
 
     @testcase.test_method_decorator
@@ -187,8 +186,7 @@ class TestSlaacAddressNcp(testcase.TestCase):
         self.wait_for_completion(self.device_list)
 
         verify_within(self.check_prefix_and_slaac_address_are_added, WAIT_INTERVAL)
-        self.assertEqual([node.find_ip6_address_with_prefix(PREFIX)
-                          for node in self.all_nodes], self.slaac_addrs)
+        self.assertEqual([node.find_ip6_address_with_prefix(PREFIX) for node in self.all_nodes], self.slaac_addrs)
 
     @testcase.test_method_decorator
     def test05_verify_remove_prefix(self):
@@ -205,8 +203,7 @@ class TestSlaacAddressNcp(testcase.TestCase):
 
         # Verify the prefix and related address gets added
         verify_within(self.check_prefix_and_slaac_address_are_added, WAIT_INTERVAL)
-        self.assertEqual([node.find_ip6_address_with_prefix(PREFIX)
-                          for node in self.all_nodes], self.slaac_addrs)
+        self.assertEqual([node.find_ip6_address_with_prefix(PREFIX) for node in self.all_nodes], self.slaac_addrs)
         # Add same prefix on r1 and verify addresses stay as before and related prefix entries gets
         # added on all the node.
         # r1 should have 3 prefix entries((1 as origin:ncp (with rloc16 of r1), 2nd as origin:user (with rloc:0x0000))
@@ -215,8 +212,7 @@ class TestSlaacAddressNcp(testcase.TestCase):
         self.r1.add_prefix(PREFIX, stable=True, on_mesh=True, slaac=True)
         self.wait_for_completion(self.device_list)
         verify_within(self.check_prefix_and_slaac_address_are_added, WAIT_INTERVAL)
-        self.assertEqual([node.find_ip6_address_with_prefix(PREFIX)
-                          for node in self.all_nodes], self.slaac_addrs)
+        self.assertEqual([node.find_ip6_address_with_prefix(PREFIX) for node in self.all_nodes], self.slaac_addrs)
 
     @testcase.test_method_decorator
     def test07_verify_removing_same_prefix(self):
@@ -225,8 +221,7 @@ class TestSlaacAddressNcp(testcase.TestCase):
         self.r1.remove_prefix(PREFIX)
         self.wait_for_completion(self.device_list)
         verify_within(self.check_prefix_and_slaac_address_are_added, WAIT_INTERVAL)
-        self.assertEqual([node.find_ip6_address_with_prefix(PREFIX)
-                          for node in self.all_nodes], self.slaac_addrs)
+        self.assertEqual([node.find_ip6_address_with_prefix(PREFIX) for node in self.all_nodes], self.slaac_addrs)
 
         # Remove the prefix on r2 and verify that the address and prefix are now removed on all nodes.
         self.r2.remove_prefix(PREFIX)
@@ -248,8 +243,7 @@ class TestSlaacAddressNcp(testcase.TestCase):
 
         # Verify due to slaac = True flag each node gets an ip address related to the prefix
         verify_within(self.check_prefix_and_slaac_address_are_added, WAIT_INTERVAL)
-        self.assertEqual([node.find_ip6_address_with_prefix(PREFIX)
-                          for node in self.all_nodes], self.slaac_addrs)
+        self.assertEqual([node.find_ip6_address_with_prefix(PREFIX) for node in self.all_nodes], self.slaac_addrs)
 
     @testcase.test_method_decorator
     def test09_verify_removing_prefix_with_different_slaac_flag(self):
@@ -295,8 +289,7 @@ class TestSlaacAddressNcp(testcase.TestCase):
         # SLAAC module should add a SLAAC address as same slaac prefix is present on r2.
         self.r1.remove_ip6_address_on_interface(IP_ADDRESS)
         verify_within(self.check_prefix_and_slaac_address_are_added, WAIT_INTERVAL)
-        self.assertEqual([node.find_ip6_address_with_prefix(PREFIX)
-                          for node in self.all_nodes], self.slaac_addrs)
+        self.assertEqual([node.find_ip6_address_with_prefix(PREFIX) for node in self.all_nodes], self.slaac_addrs)
 
         # Re-add the address
         self.r1.add_ip6_address_on_interface(IP_ADDRESS)
@@ -320,21 +313,19 @@ class TestSlaacAddressNcp(testcase.TestCase):
         # Ensure disabling SLAAC module removes previously added SLAAC addresses.
         self.r1.add_prefix(PREFIX, stable=True, on_mesh=True, slaac=True)
         verify_within(self.check_prefix_and_slaac_address_are_added, WAIT_INTERVAL)
-        self.assertEqual([node.find_ip6_address_with_prefix(PREFIX)
-                          for node in self.all_nodes], self.slaac_addrs)
+        self.assertEqual([node.find_ip6_address_with_prefix(PREFIX) for node in self.all_nodes], self.slaac_addrs)
 
         for node in self.all_nodes:
-            node.set(wpan.WPAN_OT_SLAAC_ENABLED, 'false')
+            node.set(wpan.WPAN_OT_SLAAC_ENABLED, "false")
         verify_within(self.check_slaac_address_is_removed, WAIT_INTERVAL)
 
     @testcase.test_method_decorator
     def test13_verify_enabling_slaac_module_adds_back_slaac_address(self):
         # Re-enable SLAAC support on NCP and verify addresses are re-added back.
         for node in self.all_nodes:
-            node.set(wpan.WPAN_OT_SLAAC_ENABLED, 'true')
+            node.set(wpan.WPAN_OT_SLAAC_ENABLED, "true")
         verify_within(self.check_prefix_and_slaac_address_are_added, WAIT_INTERVAL)
-        self.assertEqual([node.find_ip6_address_with_prefix(PREFIX)
-                          for node in self.all_nodes], self.slaac_addrs)
+        self.assertEqual([node.find_ip6_address_with_prefix(PREFIX) for node in self.all_nodes], self.slaac_addrs)
 
         self.r1.remove_prefix(PREFIX)
         verify_within(self.check_prefix_and_slaac_address_are_removed, WAIT_INTERVAL)
@@ -344,7 +335,7 @@ class TestSlaacAddressNcp(testcase.TestCase):
         # Check behavior when prefix is added while SLAAC is disabled and then
         # enabled later.
         for node in self.all_nodes:
-            node.set(wpan.WPAN_OT_SLAAC_ENABLED, 'false')
+            node.set(wpan.WPAN_OT_SLAAC_ENABLED, "false")
 
         # Add prefix and verify that there is no address added
         self.r1.add_prefix(PREFIX, stable=True, on_mesh=True, slaac=True)
@@ -352,10 +343,9 @@ class TestSlaacAddressNcp(testcase.TestCase):
 
         # Enable slaac module and verify the prefix and address are added.
         for node in self.all_nodes:
-            node.set(wpan.WPAN_OT_SLAAC_ENABLED, 'true')
+            node.set(wpan.WPAN_OT_SLAAC_ENABLED, "true")
         verify_within(self.check_prefix_and_slaac_address_are_added, WAIT_INTERVAL)
-        self.assertEqual([node.find_ip6_address_with_prefix(PREFIX)
-                          for node in self.all_nodes], self.slaac_addrs)
+        self.assertEqual([node.find_ip6_address_with_prefix(PREFIX) for node in self.all_nodes], self.slaac_addrs)
 
 
 if __name__ == "__main__":

--- a/silk/tests/openthread/ot_test_slaac_address_wpantund.py
+++ b/silk/tests/openthread/ot_test_slaac_address_wpantund.py
@@ -12,24 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from silk.config import wpan_constants as wpan
-from silk.tools.wpan_util import verify, verify_within
-from silk.tools import wpan_util
-from silk.tools import wpan_table_parser
-
-import silk.node.fifteen_four_dev_board as ffdb
-from silk.node.wpan_node import WpanCredentials
-import silk.hw.hw_resource as hwr
-import silk.tests.testcase as testcase
-from silk.utils import process_cleanup
-
 import random
 import unittest
 import time
 
+from silk.config import wpan_constants as wpan
+from silk.node.wpan_node import WpanCredentials
+from silk.tools import wpan_table_parser
+from silk.tools import wpan_util
+from silk.tools.wpan_util import verify, verify_within
+from silk.utils import process_cleanup
+import silk.hw.hw_resource as hwr
+import silk.node.fifteen_four_dev_board as ffdb
+import silk.tests.testcase as testcase
+
 hwr.global_instance()
 
-PREFIX = 'fd00:abba:beef:cafe::'
+PREFIX = "fd00:abba:beef:cafe::"
 IP_ADDRESS = PREFIX + "1234"
 IP_ADDRESS_2 = PREFIX + "2"
 
@@ -38,35 +37,35 @@ WAIT_INTERVAL = 5
 
 class TestSlaacAddressWpantund(testcase.TestCase):
     """
-    Test description: addition/removal of SLAAC IPv6 address by `wpantund`
-    Test topology:
-        r1 ---- r2
-               |
-               |
-             fed1
-    SLAAC prefix and user-added IPv6 addresses added are as follows:
-    - On `r1` add `PREFIX`
-    - On `r2` add `PREFIX`
-    - On `r1` add user-added `IP_ADDRESS`
-    - On `r2` add user-added `IP_ADDRESS_2`
-    This test covers the behavior of SLAAC module in wpantund:
-    - Before starting the test ensure that SLAAC module on NCP is disabled on all nodes
-    - Verify that adding prefix with SLAAC flag on a node causes following:
-        On this node: 2 entries for prefix are seen (1 as origin:ncp (with rloc16 of this node)
-                      and other as origin:user (with rloc:0x0000))
-                      Also corresponding SLAAC IPv6 address will be added
-        On other nodes: 1 entry for this prefix are seen(origin:ncp (with rloc16 of the node the prefix was added to))
-                      Also corresponding SLAAC IPv6 address will be added
-    - Verify resetting a node re-adds the SLAAC prefix and corresponding IP address back.
-    - Verify that removing the prefix, would remove the SLAAC address.
-    - Verify behavior when same prefix is added/removed on multiple nodes (with or without SLAAC flag).
-        When a prefix is added without SLAAC flag no ipv6 addresses are added on any node
-    - Check behavior when a user-added address with the same prefix already exists.
-    - Ensure removal of SLAAC prefix does not remove user-added address with same prefix.
-    """
+  Test description: addition/removal of SLAAC IPv6 address by `wpantund`
+  Test topology:
+    r1 ---- r2
+         |
+         |
+       fed1
+  SLAAC prefix and user-added IPv6 addresses added are as follows:
+  - On `r1` add `PREFIX`
+  - On `r2` add `PREFIX`
+  - On `r1` add user-added `IP_ADDRESS`
+  - On `r2` add user-added `IP_ADDRESS_2`
+  This test covers the behavior of SLAAC module in wpantund:
+  - Before starting the test ensure that SLAAC module on NCP is disabled on all nodes
+  - Verify that adding prefix with SLAAC flag on a node causes following:
+    On this node: 2 entries for prefix are seen (1 as origin:ncp (with rloc16 of this node)
+            and other as origin:user (with rloc:0x0000))
+            Also corresponding SLAAC IPv6 address will be added
+    On other nodes: 1 entry for this prefix are seen(origin:ncp (with rloc16 of the node the prefix was added to))
+            Also corresponding SLAAC IPv6 address will be added
+  - Verify resetting a node re-adds the SLAAC prefix and corresponding IP address back.
+  - Verify that removing the prefix, would remove the SLAAC address.
+  - Verify behavior when same prefix is added/removed on multiple nodes (with or without SLAAC flag).
+    When a prefix is added without SLAAC flag no ipv6 addresses are added on any node
+  - Check behavior when a user-added address with the same prefix already exists.
+  - Ensure removal of SLAAC prefix does not remove user-added address with same prefix.
+  """
 
     @classmethod
-    def hardwareSelect(cls):
+    def hardware_select(cls):
         cls.r1 = ffdb.ThreadDevBoard()
         cls.r2 = ffdb.ThreadDevBoard()
         cls.fed1 = ffdb.ThreadDevBoard()
@@ -79,19 +78,17 @@ class TestSlaacAddressWpantund(testcase.TestCase):
         # Check and clean up wpantund process if any left over
         process_cleanup.ps_cleanup()
 
-        cls.hardwareSelect()
+        cls.hardware_select()
 
         for device in cls.all_nodes:
             device.set_logger(cls.logger)
             cls.add_test_device(device)
             device.set_up()
 
-        cls.network_data = WpanCredentials(
-            network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
-            psk="00112233445566778899aabbccdd{0:04x}".
-                format(random.randint(0, 0xffff)),
-            channel=random.randint(11, 25),
-            fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
+        cls.network_data = WpanCredentials(network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
+                                           psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
+                                           channel=random.randint(11, 25),
+                                           fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
 
         cls.thread_sniffer_init(cls.network_data.channel)
 
@@ -110,8 +107,11 @@ class TestSlaacAddressWpantund(testcase.TestCase):
         pass
 
     def check_prefix_and_slaac_address_are_added(self):
-        wpan_util.verify_correct_prefix_among_similar_prefixes(self.all_nodes, PREFIX, stable=True,
-                                                               on_mesh=True, slaac=True)
+        wpan_util.verify_correct_prefix_among_similar_prefixes(self.all_nodes,
+                                                               PREFIX,
+                                                               stable=True,
+                                                               on_mesh=True,
+                                                               slaac=True)
         wpan_util.verify_address(self.all_nodes, PREFIX)
 
     def check_prefix_and_slaac_address_are_removed(self):
@@ -137,29 +137,29 @@ class TestSlaacAddressWpantund(testcase.TestCase):
         self.network_data.xpanid = self.r1.xpanid
         self.network_data.panid = self.r1.panid
 
-        self.r2.join(self.network_data, 'router')
+        self.r2.join(self.network_data, "router")
         self.wait_for_completion(self.device_list)
 
         self.fed1.join(self.network_data, "end-node")
         self.wait_for_completion(self.device_list)
 
         for _ in range(10):
-            node_type = self.r2.wpanctl('get', 'get '+wpan.WPAN_NODE_TYPE, 2).split('=')[1].strip()[1:-1]
-            self.logger.info(node_type == 'router')
+            node_type = self.r2.wpanctl("get", "get " + wpan.WPAN_NODE_TYPE, 2).split("=")[1].strip()[1:-1]
+            self.logger.info(node_type == "router")
 
-            if node_type == 'router':
-                self.logger.info('End-node moved up to a Router.')
+            if node_type == "router":
+                self.logger.info("End-node moved up to a Router.")
                 break
             time.sleep(10)
         else:
-            self.assertFalse(True, 'Router cannot get into router role after 100 seconds timeout')
+            self.assertFalse(True, "Router cannot get into router role after 100 seconds timeout")
 
     @testcase.test_method_decorator
     def test02_disable_slaac_on_ncp(self):
         # Disable slaac module on ncp on all nodes and verify it is disabled.
         for node in self.all_nodes:
-            node.setprop(wpan.WPAN_OT_SLAAC_ENABLED, 'false')
-            verify(node.get(wpan.WPAN_OT_SLAAC_ENABLED) == 'false')
+            node.setprop(wpan.WPAN_OT_SLAAC_ENABLED, "false")
+            verify(node.get(wpan.WPAN_OT_SLAAC_ENABLED) == "false")
 
     @testcase.test_method_decorator
     def test03_verify_prefix_added(self):

--- a/silk/tests/openthread/ot_test_wpan_get_set.py
+++ b/silk/tests/openthread/ot_test_wpan_get_set.py
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from silk.config import wpan_constants as wpan
-import silk.node.fifteen_four_dev_board as ffdb
-from silk.node.wpan_node import WpanCredentials
-import silk.hw.hw_resource as hwr
-import silk.tests.testcase as testcase
-from silk.utils import process_cleanup
-
 import random
 import unittest
+
+from silk.config import wpan_constants as wpan
+from silk.node.wpan_node import WpanCredentials
+from silk.utils import process_cleanup
+import silk.hw.hw_resource as hwr
+import silk.node.fifteen_four_dev_board as ffdb
+import silk.tests.testcase as testcase
 
 hwr.global_instance()
 
@@ -43,7 +43,7 @@ all_gettable_props = [
     wpan.WPAN_NCP_COUNTER_TX_IP_DROPPED,
     wpan.WPAN_NCP_COUNTER_TX_PKT_ACKED,
     wpan.WPAN_IS_COMMISSIONED,
- #   wpan.WPAN_NCP_MCU_POWER_STATE,
+    # wpan.WPAN_NCP_MCU_POWER_STATE,
     wpan.WPAN_NETWORK_ALLOW_JOIN,
     wpan.WPAN_NETWORK_PASSTHRU_PORT,
     wpan.WPAN_IP6_LINK_LOCAL_ADDRESS,
@@ -122,7 +122,7 @@ all_gettable_props = [
 class TestWpanGetSet(testcase.TestCase):
 
     @classmethod
-    def hardwareSelect(cls):
+    def hardware_select(cls):
         cls.router = ffdb.ThreadDevBoard()
 
     @classmethod
@@ -131,7 +131,7 @@ class TestWpanGetSet(testcase.TestCase):
         # Check and clean up wpantund process if any left over
         process_cleanup.ps_cleanup()
 
-        cls.hardwareSelect()
+        cls.hardware_select()
 
         cls.add_test_device(cls.router)
 
@@ -139,11 +139,10 @@ class TestWpanGetSet(testcase.TestCase):
             device.set_logger(cls.logger)
             device.set_up()
 
-        cls.network_data = WpanCredentials(
-            network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
-            psk="00112233445566778899AAbbCCdd{0:04x}".format(random.randint(0, 0xffff)),
-            channel=random.randint(11, 25),
-            fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
+        cls.network_data = WpanCredentials(network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
+                                           psk="00112233445566778899AAbbCCdd{0:04x}".format(random.randint(0, 0xffff)),
+                                           channel=random.randint(11, 25),
+                                           fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
 
         cls.thread_sniffer_init(cls.network_data.channel)
 
@@ -170,33 +169,33 @@ class TestWpanGetSet(testcase.TestCase):
 
         self.router.setprop(wpan.WPAN_NAME, self.network_data.name)
 
-        self.assertEqual(self.router.getprop(wpan.WPAN_NAME), '"'+self.network_data.name+'"')
+        self.assertEqual(self.router.getprop(wpan.WPAN_NAME), f"\"{self.network_data.name}\"")
 
-        self.router.setprop(wpan.WPAN_NAME, 'a')
-        self.assertEqual(self.router.getprop(wpan.WPAN_NAME), '"a"')
+        self.router.setprop(wpan.WPAN_NAME, "a")
+        self.assertEqual(self.router.getprop(wpan.WPAN_NAME), "\"a\"")
 
-        self.router.setprop(wpan.WPAN_PANID, '0xABBA')
-        self.assertEqual(self.router.getprop(wpan.WPAN_PANID), '0xABBA')
+        self.router.setprop(wpan.WPAN_PANID, "0xABBA")
+        self.assertEqual(self.router.getprop(wpan.WPAN_PANID), "0xABBA")
 
-        self.router.setprop(wpan.WPAN_XPANID, '1020031510006016')
-        self.assertEqual(self.router.getprop(wpan.WPAN_XPANID), '0x1020031510006016')
+        self.router.setprop(wpan.WPAN_XPANID, "1020031510006016")
+        self.assertEqual(self.router.getprop(wpan.WPAN_XPANID), "0x1020031510006016")
 
         self.router.setprop(wpan.WPAN_KEY, self.network_data.psk, data=True)
-        self.assertEqual(self.router.getprop(wpan.WPAN_KEY), '['+self.network_data.psk.upper()+']')
+        self.assertEqual(self.router.getprop(wpan.WPAN_KEY), f"[{self.network_data.psk.upper()}]")
 
-        self.router.setprop(wpan.WPAN_MAC_WHITELIST_ENABLED, '1')
-        self.assertEqual(self.router.getprop(wpan.WPAN_MAC_WHITELIST_ENABLED), 'true')
+        self.router.setprop(wpan.WPAN_MAC_WHITELIST_ENABLED, "1")
+        self.assertEqual(self.router.getprop(wpan.WPAN_MAC_WHITELIST_ENABLED), "true")
 
-        self.router.setprop(wpan.WPAN_MAC_WHITELIST_ENABLED, '0')
-        self.assertEqual(self.router.getprop(wpan.WPAN_MAC_WHITELIST_ENABLED), 'false')
+        self.router.setprop(wpan.WPAN_MAC_WHITELIST_ENABLED, "0")
+        self.assertEqual(self.router.getprop(wpan.WPAN_MAC_WHITELIST_ENABLED), "false")
 
-        self.router.setprop(wpan.WPAN_MAC_WHITELIST_ENABLED, 'true')
-        self.assertEqual(self.router.getprop(wpan.WPAN_MAC_WHITELIST_ENABLED), 'true')
+        self.router.setprop(wpan.WPAN_MAC_WHITELIST_ENABLED, "true")
+        self.assertEqual(self.router.getprop(wpan.WPAN_MAC_WHITELIST_ENABLED), "true")
 
-        self.router.setprop(wpan.WPAN_THREAD_ROUTER_UPGRADE_THRESHOLD, '100')
+        self.router.setprop(wpan.WPAN_THREAD_ROUTER_UPGRADE_THRESHOLD, "100")
         self.assertEqual(int(self.router.getprop(wpan.WPAN_THREAD_ROUTER_UPGRADE_THRESHOLD), 0), 100)
 
-        self.router.setprop(wpan.WPAN_THREAD_ROUTER_DOWNGRADE_THRESHOLD, '40')
+        self.router.setprop(wpan.WPAN_THREAD_ROUTER_DOWNGRADE_THRESHOLD, "40")
         self.assertEqual(int(self.router.getprop(wpan.WPAN_THREAD_ROUTER_DOWNGRADE_THRESHOLD), 0), 40)
 
     @testcase.test_method_decorator
@@ -208,9 +207,9 @@ class TestWpanGetSet(testcase.TestCase):
             value = self.router.get(prop)
             print(value)
 
-            self.assertFalse('Property Not Found' in value, 'Property: {} was not found !!!'.format(prop))
+            self.assertFalse("Property Not Found" in value, f"Property: {prop} was not found !!!")
 
-            self.assertFalse('Error' in value, 'Getting property {} comes with error !!!! '.format(prop))
+            self.assertFalse("Error" in value, f"Getting property {prop} comes with error !!!! ")
 
 
 if __name__ == "__main__":

--- a/silk/tests/openthread/test_firmware_upgrade.py
+++ b/silk/tests/openthread/test_firmware_upgrade.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import silk.node.fifteen_four_dev_board as ffdb
-import silk.hw.hw_resource as hwr
-import silk.tests.testcase as testcase
-from silk.utils import process_cleanup
 import time
 
-FIRMWARE_FILE_CDC = '/opt/openthread_test/nrf52840_image/ot-ncp-ftd.hex'
-FIRMWARE_FILE_CLI = '/opt/openthread_test/nrf52840_image/ot-cli-ftd.hex'
+from silk.utils import process_cleanup
+import silk.hw.hw_resource as hwr
+import silk.node.fifteen_four_dev_board as ffdb
+import silk.tests.testcase as testcase
+
+FIRMWARE_FILE_CDC = "/opt/openthread_test/nrf52840_image/ot-ncp-ftd.hex"
+FIRMWARE_FILE_CLI = "/opt/openthread_test/nrf52840_image/ot-cli-ftd.hex"
 
 hwr.global_instance()
 
@@ -27,7 +28,7 @@ hwr.global_instance()
 class TestFirmwareUpgrade(testcase.TestCase):
 
     @classmethod
-    def hardwareSelect(cls):
+    def hardware_select(cls):
         cls.device_list = []
 
         # Get all connected devices
@@ -46,7 +47,7 @@ class TestFirmwareUpgrade(testcase.TestCase):
         # Check and clean up wpantund process if any left over
         process_cleanup.ps_cleanup()
 
-        cls.hardwareSelect()
+        cls.hardware_select()
 
         for d in cls.device_list:
             d.set_logger(cls.logger)
@@ -75,10 +76,9 @@ class TestFirmwareUpgrade(testcase.TestCase):
             self.wait_for_completion(self.device_list)
             result_list.append((device.device.get_dut_serial(), device.flash_result))
 
-        self.logger.info('Firmware upgrade results:')
+        self.logger.info("Firmware upgrade results:")
         self.logger.info(result_list)
 
         overall_result = all(r for _, r in result_list)
-        self.assertTrue(overall_result, 'Firmware upgrade failed on devices or all devices. Please check the log.')
-
-
+        self.assertTrue(overall_result, ("Firmware upgrade failed on devices or all devices."
+                                         " Please check the log."))

--- a/silk/tests/openthread/test_wpantund_start.py
+++ b/silk/tests/openthread/test_wpantund_start.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import silk.node.fifteen_four_dev_board as ffdb
-import silk.hw.hw_resource as hwr
-import silk.tests.testcase as testcase
-from silk.utils import process_cleanup
-
-import unittest
 import time
+import unittest
+
+from silk.utils import process_cleanup
+import silk.hw.hw_resource as hwr
+import silk.node.fifteen_four_dev_board as ffdb
+import silk.tests.testcase as testcase
 
 hwr.global_instance()
 
@@ -27,7 +27,7 @@ class TestWpantundStart(testcase.TestCase):
     poll_interval = 1000
 
     @classmethod
-    def hardwareSelect(cls):
+    def hardware_select(cls):
         cls.router = ffdb.ThreadDevBoard()
         cls.joiner_list = []
 
@@ -43,10 +43,11 @@ class TestWpantundStart(testcase.TestCase):
     @classmethod
     @testcase.setup_class_decorator
     def setUpClass(cls):
-        # Check and clean up wpantund process if any left over
+        """Check and clean up wpantund process if any left over.
+    """
         process_cleanup.ps_cleanup()
 
-        cls.hardwareSelect()
+        cls.hardware_select()
 
         cls.add_test_device(cls.router)
 

--- a/silk/tests/silk_replay.py
+++ b/silk/tests/silk_replay.py
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Silk Test Log Visualization Replayer.
 
 Enables replaying Silk log with OTNS enabled through OTNS visualization.
 """
 
-import argparse
 from datetime import datetime
+import argparse
 import enum
 import logging
 import os
@@ -26,267 +25,268 @@ import re
 import sys
 import time
 
-import silk.hw.hw_resource as hw_resource
-import silk.node.fifteen_four_dev_board as ffdb
 from silk.tools.otns_manager import OtnsManager, OtnsNodeSummaryCollection
 from silk.tools.otns_manager import RegexType as OtnsRegexType
+import silk.hw.hw_resource as hw_resource
+import silk.node.fifteen_four_dev_board as ffdb
 
 DATE_FORMAT = "%Y-%m-%d %H:%M:%S,%f"
 LOG_LINE_FORMAT = "[%(asctime)s] [%(name)s] [%(levelname)s] %(message)s"
 
 
 class RegexType(enum.Enum):
-  """Regular expression collections.
-  """
-  # regex that matches the four components above as groups
-  LOG_LINE = r"\[([\d\s,:-]+)\] \[([\w\d.-]+)\] \[(\w+)\] (.+)"
-  SET_UP_CLASS = r"SET UP CLASS (\w+)"
-  TEARDOWN_CLASS = r"TEAR DOWN CLASS (\w+)"
-  TEARDOWN_CLASS_DONE = r"TEAR DOWN CLASS DONE (\w+)"
-  RUNNING_TEST = r"RUNNING TEST ([\w._]+)"
+    """Regular expression collections.
+    """
+    # regex that matches the four components above as groups
+    LOG_LINE = r"\[([\d\s,:-]+)\] \[([\w\d.-]+)\] \[(\w+)\] (.+)"
+    SET_UP_CLASS = r"SET UP CLASS (\w+)"
+    TEARDOWN_CLASS = r"TEAR DOWN CLASS (\w+)"
+    TEARDOWN_CLASS_DONE = r"TEAR DOWN CLASS DONE (\w+)"
+    RUNNING_TEST = r"RUNNING TEST ([\w._]+)"
 
 
 class SilkReplayer(object):
-  """Replay topology changes and transmissions from a Silk log.
+    """Replay topology changes and transmissions from a Silk log.
 
-  Attributes:
-    speed (float): speed ratio for the replay. 2.0 means speeding up to 2x.
-    verbosity (int): terminal log verbosity.
-    input_path (str): input Silk log file path.
-    log_filename (str): name of input log file.
-    logger (logging.Logger): logger for the replayer.
+    Attributes:
+        speed (float): speed ratio for the replay. 2.0 means speeding up to 2x.
+        verbosity (int): terminal log verbosity.
+        input_path (str): input Silk log file path.
+        log_filename (str): name of input log file.
+        logger (logging.Logger): logger for the replayer.
 
-    device_names (Set[str]): name of hardware modules from hwconfig.ini file.
-    device_name_map (Dict[str, ThreadDevBoard]): map from device name to
-      ThreadDevBoard instance.
-    otns_manager (OtnsManager): manager for OTNS communications.
+        device_names (Set[str]): name of hardware modules from hwconfig.ini file.
+        device_name_map (Dict[str, ThreadDevBoard]): map from device name to
+        ThreadDevBoard instance.
+        otns_manager (OtnsManager): manager for OTNS communications.
 
-    last_time (datetime.datetime): timestamp of the last line of log processed.
-  """
-
-  def __init__(self, argv=None):
-    """Initialize a Silk log replayer.
-
-    Args:
-      argv (List[str], optional): command line arguments. Defaults to None.
+        last_time (datetime.datetime): timestamp of the last line of log processed.
     """
-    args = self.parse_args(argv)
-    self.verbosity = args.verbosity
-    self.input_path = args.path
-    self.log_filename = os.path.basename(args.path)
-    self.speed = float(args.playback_speed)
 
-    self.set_up_logger(args.results_dir or os.getcwd())
-    self.acquire_devices(args.hw_conf_file)
+    def __init__(self, argv=None):
+        """Initialize a Silk log replayer.
 
-    self.otns_manager = OtnsManager(
-        server_host=args.otns_server,
-        logger=self.logger.getChild("otnsManager"))
+        Args:
+        argv (List[str], optional): command line arguments. Defaults to None.
+        """
+        args = self.parse_args(argv)
+        self.verbosity = args.verbosity
+        self.input_path = args.path
+        self.log_filename = os.path.basename(args.path)
+        self.speed = float(args.playback_speed)
 
-    self.last_time = None
-    self.run()
+        self.set_up_logger(args.results_dir or os.getcwd())
+        self.acquire_devices(args.hw_conf_file)
 
-    result_path = os.path.join(
-        args.results_dir, f"silk_replay_summary_for_{self.log_filename}.csv")
-    self.output_summary(coalesced=True, csv_path=result_path)
+        self.otns_manager = OtnsManager(server_host=args.otns_server, logger=self.logger.getChild("otnsManager"))
 
-  def set_up_logger(self, result_dir: str):
-    """Set up logger for the replayer.
+        self.last_time = None
+        self.run()
 
-    Args:
-      result_dir (str): output directory of log.
-    """
-    if self.verbosity == 0:
-      stream_level = logging.CRITICAL
-    elif self.verbosity == 1:
-      stream_level = logging.INFO
-    else:
-      stream_level = logging.DEBUG
+        result_path = os.path.join(args.results_dir, f"silk_replay_summary_for_{self.log_filename}.csv")
+        self.output_summary(coalesced=True, csv_path=result_path)
 
-    logging.basicConfig(format=LOG_LINE_FORMAT, level=stream_level)
+    def set_up_logger(self, result_dir: str):
+        """Set up logger for the replayer.
 
-    self.logger = logging.getLogger("silk_replay")
-    self.logger.setLevel(logging.DEBUG)
+        Args:
+        result_dir (str): output directory of log.
+        """
+        if self.verbosity == 0:
+            stream_level = logging.CRITICAL
+        elif self.verbosity == 1:
+            stream_level = logging.INFO
+        else:
+            stream_level = logging.DEBUG
 
-    formatter = logging.Formatter(LOG_LINE_FORMAT)
+        logging.basicConfig(format=LOG_LINE_FORMAT, level=stream_level)
 
-    result_path = os.path.join(
-        result_dir, f"silk_replay_log_for_{self.log_filename}.log")
+        self.logger = logging.getLogger("silk_replay")
+        self.logger.setLevel(logging.DEBUG)
 
-    file_handler = logging.FileHandler(result_path, mode="w")
-    file_handler.setLevel(logging.DEBUG)
-    file_handler.setFormatter(formatter)
+        formatter = logging.Formatter(LOG_LINE_FORMAT)
 
-    if self.logger.hasHandlers():
-      self.logger.handlers.clear()
-    self.logger.addHandler(file_handler)
+        result_path = os.path.join(result_dir, f"silk_replay_log_for_{self.log_filename}.log")
 
-  def parse_args(self, argv):
-    """Parse arguments.
+        file_handler = logging.FileHandler(result_path, mode="w")
+        file_handler.setLevel(logging.DEBUG)
+        file_handler.setFormatter(formatter)
 
-    Args:
-      argv (List[str]): command line arguments.
+        if self.logger.hasHandlers():
+            self.logger.handlers.clear()
+        self.logger.addHandler(file_handler)
 
-    Returns:
-      argparse.Namespace: parsed arguments attributes.
-    """
-    parser = argparse.ArgumentParser(description="Replay a Silk test log")
-    parser.add_argument("-r", "--results_dir", dest="results_dir",
-                        metavar="ResPath",
-                        help="Set the path for run results")
-    parser.add_argument("-c", "--hwconfig", dest="hw_conf_file",
-                        metavar="ConfFile",
-                        default="/opt/openthread_test/hwconfig.ini",
-                        help="Name the hardware config file")
-    parser.add_argument("-v", "--verbose", "--verbosity", type=int,
-                        default=1, choices=list(range(0, 3)),
-                        dest="verbosity", metavar="X",
-                        help="Verbosity level (0=quiet, 1=default, 2=verbose)")
-    parser.add_argument("-s", "--otns", dest="otns_server",
-                        metavar="OtnsServer",
-                        default="localhost",
-                        help="OTNS server address")
-    parser.add_argument("-p", "--speed", dest="playback_speed",
-                        type=float, default=1.0,
-                        metavar="PlaybackSpeed",
-                        help="Speed of log replay")
-    parser.add_argument("path", metavar="P",
-                        help="Log file path")
-    return parser.parse_args(argv[1:])
+    def parse_args(self, argv):
+        """Parse arguments.
 
-  def acquire_devices(self, config_file: str):
-    """Acquire devices from hwconfig.ini file.
+        Args:
+        argv (List[str]): command line arguments.
 
-    Args:
-      config_file (str): path to hwconfig.ini file.
-    """
-    hw_resource.global_instance(config_file, virtual=True)
-    hw_resource.global_instance().load_config()
-    self.device_names = set(
-        hw_resource.global_instance().get_hw_module_names())
-    self.device_name_map = dict()
-    self.logger.debug(f"Loaded devices {self.device_names}")
+        Returns:
+        argparse.Namespace: parsed arguments attributes.
+        """
+        parser = argparse.ArgumentParser(description="Replay a Silk test log")
+        parser.add_argument("-r",
+                            "--results_dir",
+                            dest="results_dir",
+                            metavar="ResPath",
+                            help="Set the path for run results")
+        parser.add_argument("-c",
+                            "--hwconfig",
+                            dest="hw_conf_file",
+                            metavar="ConfFile",
+                            default="/opt/openthread_test/hwconfig.ini",
+                            help="Name the hardware config file")
+        parser.add_argument("-v",
+                            "--verbose",
+                            "--verbosity",
+                            type=int,
+                            default=1,
+                            choices=list(range(0, 3)),
+                            dest="verbosity",
+                            metavar="X",
+                            help="Verbosity level (0=quiet, 1=default, 2=verbose)")
+        parser.add_argument("-s",
+                            "--otns",
+                            dest="otns_server",
+                            metavar="OtnsServer",
+                            default="localhost",
+                            help="OTNS server address")
+        parser.add_argument("-p",
+                            "--speed",
+                            dest="playback_speed",
+                            type=float,
+                            default=1.0,
+                            metavar="PlaybackSpeed",
+                            help="Speed of log replay")
+        parser.add_argument("path", metavar="P", help="Log file path")
+        return parser.parse_args(argv[1:])
 
-  def execute_message(self, entity_name: str, message: str,
-                      timestamp: datetime):
-    """Execute the intended action represented by the message.
+    def acquire_devices(self, config_file: str):
+        """Acquire devices from hwconfig.ini file.
 
-    Args:
-      entity_name (str): name of the entity carrying out the action.
-      message (str): message content of the action.
-      timestamp (datetime.datetime): timestamp of the message.
-    """
-    parts = entity_name.split(".")
-    if len(parts) == 1 and parts[0] == "silk":
-      set_up_class_match = re.match(RegexType.SET_UP_CLASS.value, message)
-      if set_up_class_match:
-        self.otns_manager.set_test_title(
-            f"{set_up_class_match.group(1)}.set_up")
-        return
+        Args:
+        config_file (str): path to hwconfig.ini file.
+        """
+        hw_resource.global_instance(config_file, virtual=True)
+        hw_resource.global_instance().load_config()
+        self.device_names = set(hw_resource.global_instance().get_hw_module_names())
+        self.device_name_map = dict()
+        self.logger.debug("Loaded devices {}".format(self.device_names))
 
-      teardown_class_done_match = re.match(
-          RegexType.TEARDOWN_CLASS_DONE.value, message)
-      if teardown_class_done_match:
-        self.otns_manager.set_test_title("")
-        return
+    def execute_message(self, entity_name: str, message: str, timestamp: datetime):
+        """Execute the intended action represented by the message.
 
-      teardown_class_match = re.match(RegexType.TEARDOWN_CLASS.value, message)
-      if teardown_class_match:
-        self.otns_manager.set_test_title(
-            f"{teardown_class_match.group(1)}.tear_down")
-        return
+        Args:
+        entity_name (str): name of the entity carrying out the action.
+        message (str): message content of the action.
+        timestamp (datetime.datetime): timestamp of the message.
+        """
+        parts = entity_name.split(".")
+        if len(parts) == 1 and parts[0] == "silk":
+            set_up_class_match = re.match(RegexType.SET_UP_CLASS.value, message)
+            if set_up_class_match:
+                self.otns_manager.set_test_title(f"{set_up_class_match.group(1)}.set_up")
+                return
 
-      running_test_match = re.match(RegexType.RUNNING_TEST.value, message)
-      if running_test_match:
-        self.otns_manager.set_test_title(running_test_match.group(1))
-        return
-    if len(parts) < 2 or parts[0] != "silk" or parts[1] == "otnsManager":
-      return
+            teardown_class_done_match = re.match(RegexType.TEARDOWN_CLASS_DONE.value, message)
+            if teardown_class_done_match:
+                self.otns_manager.set_test_title("")
+                return
 
-    device_name = parts[1]
-    if device_name not in self.device_names:
-      return
+            teardown_class_match = re.match(RegexType.TEARDOWN_CLASS.value, message)
+            if teardown_class_match:
+                self.otns_manager.set_test_title(f"{teardown_class_match.group(1)}.tear_down")
+                return
 
-    if device_name not in self.device_name_map:
-      device = ffdb.ThreadDevBoard(virtual=True, virtual_name=device_name)
-      self.device_name_map[device_name] = device
-    else:
-      device = self.device_name_map[device_name]
+            running_test_match = re.match(RegexType.RUNNING_TEST.value, message)
+            if running_test_match:
+                self.otns_manager.set_test_title(running_test_match.group(1))
+                return
+        if len(parts) < 2 or parts[0] != "silk" or parts[1] == "otnsManager":
+            return
 
-    start_match = re.match(OtnsRegexType.START_WPANTUND_RES.value, message)
-    if start_match:
-      self.otns_manager.add_node(device)
-      return
+        device_name = parts[1]
+        if device_name not in self.device_names:
+            return
 
-    stop_match = re.match(OtnsRegexType.STOP_WPANTUND_REQ.value, message)
-    if stop_match:
-      self.otns_manager.remove_node(device)
-      return
+        if device_name not in self.device_name_map:
+            device = ffdb.ThreadDevBoard(virtual=True, virtual_name=device_name)
+            self.device_name_map[device_name] = device
+        else:
+            device = self.device_name_map[device_name]
 
-    extaddr_match = re.search(OtnsRegexType.GET_EXTADDR_RES.value, message)
-    if extaddr_match:
-      self.otns_manager.update_extaddr(
-          device, int(extaddr_match.group(1), 16), time=timestamp)
-      return
+        start_match = re.match(OtnsRegexType.START_WPANTUND_RES.value, message)
+        if start_match:
+            self.otns_manager.add_node(device)
+            return
 
-    ncp_version_match = re.search(OtnsRegexType.NCP_VERSION.value, message)
-    if ncp_version_match:
-      ncp_version = ncp_version_match.group(1)
-      self.otns_manager.set_ncp_version(ncp_version)
-      return
+        stop_match = re.match(OtnsRegexType.STOP_WPANTUND_REQ.value, message)
+        if stop_match:
+            self.otns_manager.remove_node(device)
+            return
 
-    status_match = re.match(OtnsRegexType.STATUS.value, message)
-    if status_match:
-      self.otns_manager.process_node_status(device, message, time=timestamp)
-      return
+        extaddr_match = re.search(OtnsRegexType.GET_EXTADDR_RES.value, message)
+        if extaddr_match:
+            self.otns_manager.update_extaddr(device, int(extaddr_match.group(1), 16), time=timestamp)
+            return
 
-  def output_summary(self, coalesced: bool, csv_path: str):
-    """Print summary of the replayed log.
+        ncp_version_match = re.search(OtnsRegexType.NCP_VERSION.value, message)
+        if ncp_version_match:
+            ncp_version = ncp_version_match.group(1)
+            self.otns_manager.set_ncp_version(ncp_version)
+            return
 
-    Args:
-      coalesced (bool): if the summary should be printed grouped by time.
-      csv_path (str): path to CSV output file
-    """
-    extaddr_map = {}
-    for summary in self.otns_manager.node_summaries.values():
-      if summary.extaddr_history:
-        extaddr_map[summary.extaddr_history[-1][1]] = summary.node_id
-    if csv_path:
-      collection = OtnsNodeSummaryCollection(
-          self.otns_manager.node_summaries.values())
-      data_frame = collection.to_csv(extaddr_map)
-      data_frame.to_csv(csv_path, index=False)
-    elif coalesced:
-      collection = OtnsNodeSummaryCollection(
-          self.otns_manager.node_summaries.values())
-      self.logger.debug(collection.to_string(extaddr_map))
-    else:
-      for summary in self.otns_manager.node_summaries.values():
-        self.logger.debug(summary.to_string(extaddr_map))
+        status_match = re.match(OtnsRegexType.STATUS.value, message)
+        if status_match:
+            self.otns_manager.process_node_status(device, message, time=timestamp)
+            return
 
-  def run(self):
-    """Run the Silk log replayer.
-    """
-    self.otns_manager.set_replay_speed(self.speed)
-    with open(file=self.input_path, mode="r") as file:
-      for line in file:
-        line_match = re.search(RegexType.LOG_LINE.value, line)
-        if line_match:
-          timestamp = datetime.strptime(line_match.group(1), DATE_FORMAT)
-          if not self.last_time:
-            self.last_time = timestamp
-          time_diff = timestamp - self.last_time
-          delay = time_diff.total_seconds() / self.speed
-          self.last_time = timestamp
+    def output_summary(self, coalesced: bool, csv_path: str):
+        """Print summary of the replayed log.
 
-          entity_name = line_match.group(2)
-          message = line_match.group(4)
+        Args:
+        coalesced (bool): if the summary should be printed grouped by time.
+        csv_path (str): path to CSV output file
+        """
+        extaddr_map = {}
+        for summary in self.otns_manager.node_summaries.values():
+            if summary.extaddr_history:
+                extaddr_map[summary.extaddr_history[-1][1]] = summary.node_id
+        if csv_path:
+            collection = OtnsNodeSummaryCollection(self.otns_manager.node_summaries.values())
+            data_frame = collection.to_csv(extaddr_map)
+            data_frame.to_csv(csv_path, index=False)
+        elif coalesced:
+            collection = OtnsNodeSummaryCollection(self.otns_manager.node_summaries.values())
+            self.logger.debug(collection.to_string(extaddr_map))
+        else:
+            for summary in self.otns_manager.node_summaries.values():
+                self.logger.debug(summary.to_string(extaddr_map))
 
-          # delay for the time difference between two log lines
-          if delay > 0:
-            time.sleep(delay)
-          self.execute_message(entity_name, message, timestamp)
+    def run(self):
+        """Run the Silk log replayer.
+        """
+        self.otns_manager.set_replay_speed(self.speed)
+        with open(file=self.input_path, mode="r") as file:
+            for line in file:
+                line_match = re.search(RegexType.LOG_LINE.value, line)
+                if line_match:
+                    timestamp = datetime.strptime(line_match.group(1), DATE_FORMAT)
+                    if not self.last_time:
+                        self.last_time = timestamp
+                    time_diff = timestamp - self.last_time
+                    delay = time_diff.total_seconds() / self.speed
+                    self.last_time = timestamp
+
+                    entity_name = line_match.group(2)
+                    message = line_match.group(4)
+
+                    # delay for the time difference between two log lines
+                    if delay > 0:
+                        time.sleep(delay)
+                    self.execute_message(entity_name, message, timestamp)
 
 
 if __name__ == "__main__":
-  SilkReplayer(argv=sys.argv)
+    SilkReplayer(argv=sys.argv)

--- a/silk/tests/silk_run.py
+++ b/silk/tests/silk_run.py
@@ -11,44 +11,40 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-""" Silk Test Runner
+"""Silk Test Runner.
 
 Enables the discovery and running of Silk Tests from the command line.
 """
 
-from builtins import str
-from builtins import range
-from builtins import object
 import argparse
+import logging
+import os
 import sys
 import time
 import unittest
-import os
 
 import silk.hw.hw_resource as hw_resource
 import silk.tests.testcase
-import logging
 
 
 class Colors(object):
-    BLACK = '\033[30m'
-    RED = '\033[31m'
-    GREEN = '\033[32m'
-    YELLOW = '\033[33m'
-    BLUE = '\033[34m'
-    MAGENTA = '\033[35m'
-    CYAN = '\033[36m'
-    WHITE = '\033[37m'
-    ENDC = '\033[0m'
+    BLACK = "\033[30m"
+    RED = "\033[31m"
+    GREEN = "\033[32m"
+    YELLOW = "\033[33m"
+    BLUE = "\033[34m"
+    MAGENTA = "\033[35m"
+    CYAN = "\033[36m"
+    WHITE = "\033[37m"
+    ENDC = "\033[0m"
 
 
-RESULT_LOG_PATH = '/opt/openthread_test/results/'
-CONFIG_PATH = '/opt/openthread_test/'
+RESULT_LOG_PATH = "/opt/openthread_test/results/"
+CONFIG_PATH = "/opt/openthread_test/"
 
 
 class SilkTestResult(unittest.TestResult):
-    """ TestResult class to maintain and display silk results
+    """TestResult class to maintain and display silk results.
 
     This class extends the base class to maintain order of tests run and to
     display the result in summary form.
@@ -70,18 +66,19 @@ class SilkTestResult(unittest.TestResult):
         if results_dir:
             if not os.path.exists(results_dir):
                 os.makedirs(results_dir)
-            logging.basicConfig(format='%(levelname)s:%(message)s', filename=results_dir+'/test_summary.log',
+            logging.basicConfig(format="%(levelname)s:%(message)s",
+                                filename=results_dir + "/test_summary.log",
                                 level=logging.DEBUG)
         else:
-            logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.DEBUG)
+            logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.DEBUG)
 
-    def addSuccess(self, test): 
+    def addSuccess(self, test):
         unittest.TestResult.addSuccess(self, test)
         self.successes.append(test)
         if self.verbosity == 0:
             self.printTestResultLine(test, self.result_pass)
 
-    def addFailure(self, test, err): 
+    def addFailure(self, test, err):
         unittest.TestResult.addFailure(self, test, err)
         if self.verbosity == 0:
             self.printTestResultLine(test, self.result_fail)
@@ -93,24 +90,24 @@ class SilkTestResult(unittest.TestResult):
     def printTestSummary(self):
         self.printTestErrors()
         self.printTestResults()
-        self.printBanner('SUMMARY')
+        self.printBanner("SUMMARY")
         end_time = time.time()
-        self.printStatLine('Start time:', time.ctime(self.startTime))
-        self.printStatLine('End time:', time.ctime(end_time))
-        self.printStatLine('Execution time:', time.strftime('%H:%M:%S', time.gmtime(time.time() - self.startTime)))
-        self.printStatLine('Tests skipped:', len(self.skipped))
-        self.printStatLine('Tests errors:', len(self.errors))
-        self.printStatLine('Tests run:', self.testsRun)
-        self.printStatLine('Tests passed:', len(self.successes))
-        self.printStatLine('Tests failed:', len(self.failures))
+        self.printStatLine("Start time:", time.ctime(self.startTime))
+        self.printStatLine("End time:", time.ctime(end_time))
+        self.printStatLine("Execution time:", time.strftime("%H:%M:%S", time.gmtime(time.time() - self.startTime)))
+        self.printStatLine("Tests skipped:", len(self.skipped))
+        self.printStatLine("Tests errors:", len(self.errors))
+        self.printStatLine("Tests run:", self.testsRun)
+        self.printStatLine("Tests passed:", len(self.successes))
+        self.printStatLine("Tests failed:", len(self.failures))
 
     def printStatLine(self, name, result):
-        print('{0}{1}'.format(name.ljust(16), result))
-        logging.info('{0}{1}'.format(name.ljust(16), result))
+        print("{0}{1}".format(name.ljust(16), result))
+        logging.info("{0}{1}".format(name.ljust(16), result))
 
     def printTestResults(self):
         if self.verbosity > 0:
-            self.printBanner('TEST RESULTS RECAP')
+            self.printBanner("TEST RESULTS RECAP")
             self.current_testclass = None
             for t in self.testlist:
                 self.printTestFailure(t)
@@ -128,30 +125,30 @@ class SilkTestResult(unittest.TestResult):
 
     def printTestResultLine(self, test, result):
         if self.testsRun == 1:
-            self.printBanner('TEST RESULTS')
+            self.printBanner("TEST RESULTS")
         if test.__class__ != self.current_testclass:
             self.current_testclass = test.__class__
             tc = test.__class__
-            print('{0}.{1}'.format(tc.__module__, tc.__name__))
-            logging.info('{0}.{1}'.format(tc.__module__, tc.__name__))
+            print("{0}.{1}".format(tc.__module__, tc.__name__))
+            logging.info("{0}.{1}".format(tc.__module__, tc.__name__))
 
-        print('    {0}{1}'.format(test._testMethodName.ljust(self.testname_spacing, '.'), result))
-        logging.info('    {0}{1}'.format(test._testMethodName.ljust(self.testname_spacing, '.'), result))
+        print("    {0}{1}".format(test._testMethodName.ljust(self.testname_spacing, "."), result))
+        logging.info("    {0}{1}".format(test._testMethodName.ljust(self.testname_spacing, "."), result))
 
     def printTestErrors(self):
-        self.printBanner('HARDWARE TEST SET-UP ERRORS')
+        self.printBanner("HARDWARE TEST SET-UP ERRORS")
         for e in self.errors:
             print(str(e[0]))
             print(str(e[1]))
 
     def printBanner(self, title):
-        print('\n')
-        print('=' * self.line_length)
-        logging.info('=' * self.line_length)
-        print(title.join([' ', ' ']).center(self.line_length, '='))
-        logging.info(title.join([' ', ' ']).center(self.line_length, '='))
-        print('=' * self.line_length)
-        logging.info('=' * self.line_length)
+        print("\n")
+        print("=" * self.line_length)
+        logging.info("=" * self.line_length)
+        print(title.join([" ", " "]).center(self.line_length, "="))
+        logging.info(title.join([" ", " "]).center(self.line_length, "="))
+        print("=" * self.line_length)
+        logging.info("=" * self.line_length)
 
 
 class SilkRunner(object):
@@ -164,49 +161,54 @@ class SilkRunner(object):
         self.pattern = args.pattern
         self.results_dir = args.results_dir
         if args.results_dir is not None:
-            print('Setting results dir to {0}'.format(args.results_dir))
-            silk.tests.testcase.setOutputDirectory(args.results_dir)
+            print("Setting results dir to {0}".format(args.results_dir))
+            silk.tests.testcase.set_output_directory(args.results_dir)
         if args.otns_server is not None:
-            print('Setting OTNS server host to {0}'.format(args.otns_server))
+            print("Setting OTNS server host to {0}".format(args.otns_server))
             silk.tests.testcase.setOtnsHost(args.otns_server)
-        silk.tests.testcase.setStreamVerbosity(self.verbosity)
+        silk.tests.testcase.set_stream_verbosity(self.verbosity)
         hw_resource.global_instance(args.hw_conf_file)
 
         self.discover()
         self.run()
 
     def parseArgs(self, argv):
-        parser = argparse.ArgumentParser(
-            description='Run a suite of Silk Tests')
-        parser.add_argument('-d', '--results_dir', dest='results_dir',
-            metavar='ResPath',
-            help='Set the directory path for test results')
-        parser.add_argument('-c', '--hwconfig', dest='hw_conf_file',
-            metavar='ConfFile',
-            help='Name the hardware config file')
-        parser.add_argument('-v', '--verbose', '--verbosity', type=int,
-            default=1, choices=list(range(0, 3)), dest='verbosity', metavar='X',
-            help='Set the verbosity level of the console (0=quiet, 1=default, 2=verbose)')
-        parser.add_argument('pattern', nargs='+', metavar='P',
-            help='test file search pattern')
-        parser.add_argument('-s', '--otns', dest='otns_server',
-            metavar='OtnsServer',
-            help='OTNS server address')
+        parser = argparse.ArgumentParser(description="Run a suite of Silk Tests")
+        parser.add_argument("-d",
+                            "--results_dir",
+                            dest="results_dir",
+                            metavar="ResPath",
+                            help="Set the directory path for test results")
+        parser.add_argument("-c",
+                            "--hwconfig",
+                            dest="hw_conf_file",
+                            metavar="ConfFile",
+                            help="Name the hardware config file")
+        parser.add_argument("-v",
+                            "--verbose",
+                            "--verbosity",
+                            type=int,
+                            default=1,
+                            choices=list(range(0, 3)),
+                            dest="verbosity",
+                            metavar="X",
+                            help="Set the verbosity level of the console (0=quiet, 1=default, 2=verbose)")
+        parser.add_argument("pattern", nargs="+", metavar="P", help="test file search pattern")
+        parser.add_argument("-s", "--otns", dest="otns_server", metavar="OtnsServer", help="OTNS server address")
         return parser.parse_args(argv[1:])
 
     def discover(self):
         self.test_suite = unittest.TestSuite()
         for p in self.pattern:
-            self.test_suite.addTest(unittest.defaultTestLoader.discover('./', p))
-        print('Found {0} test cases.'.format(self.test_suite.countTestCases()))
+            self.test_suite.addTest(unittest.defaultTestLoader.discover("./", p))
+        print("Found {0} test cases.".format(self.test_suite.countTestCases()))
 
     def run(self):
-        print('Running tests...')
+        print("Running tests...")
         tr = SilkTestResult(self.verbosity, self.results_dir)
         self.test_suite.run(tr)
         tr.printTestSummary()
 
 
 if __name__ == "__main__":
-    #sys.argv = ['tests/silk_run.py', '-v2', '-c', CONFIG_PATH+'hwconfig.ini', '-d', RESULT_LOG_PATH,  'ot_test_form_network.py']
     SilkRunner(argv=sys.argv)

--- a/silk/tools/deadline.py
+++ b/silk/tools/deadline.py
@@ -11,32 +11,36 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+"""Various time and timeout related utilties.
 """
-Various time and timeout related utilties
-"""
-from __future__ import print_function
 
-from builtins import object
 import datetime
 
 
-# A class encapsulating tracking of a timeout
-# Useful for cases where a timeout is passed in by the user and successive calls
-# to blocking calls with timeouts need to be performed with timeout values adjusted
-# according to the time remaining
 class Deadline(object):
-    # Constructor
-    # @param timeout The timeout, in seconds. Specify None for an "infinite" timeout
-    # @param start_now Whether to start tracking time passed now or wait until the first call
-    def __init__(self, timeout = None, start_now = False):
+    """A class encapsulating tracking of a timeout.
+
+    Useful for cases where a timeout is passed in by the user and successive
+    calls to blocking calls with timeouts need to be performed with timeout
+    values adjusted according to the time remaining.
+    """
+
+    def __init__(self, timeout: float = None, start_now: bool = False):
+        """Constructor.
+
+        Args:
+            timeout (float, optional): The timeout, in seconds. Specify None for
+                an "infinite" timeout. Defaults to None.
+            start_now (bool, optional): Whether to start tracking time passed now
+                or wait until the first call. Defaults to False.
+        """
         self.__timeout = None
 
         self.__start_time = None
         self.__end_time = None
 
         if timeout is not None:
-            self.__timeout = datetime.timedelta(seconds = timeout)
+            self.__timeout = datetime.timedelta(seconds=timeout)
 
         if start_now:
             self.__calculate_start_time()
@@ -50,15 +54,22 @@ class Deadline(object):
 
         return retval
 
-    # Start tracking the time passed from now. Will throw a RuntimeError if tracking was already started
     def start(self):
+        """Start tracking the time passed from now.
+
+        Raises:
+            RuntimeError: raised if tracking was already started.
+        """
         started = self.__calculate_start_time()
-        if started == False:
+        if not started:
             raise RuntimeError("Tracking already started")
 
-    # Get the remaining time left, in seconds
-    # @returns The time left in seconds
-    def get_remaining_seconds(self):
+    def get_remaining_seconds(self) -> float:
+        """Get the remaining time left, in seconds.
+
+        Returns:
+            float: The time left in seconds.
+        """
         retval = None
 
         self.__calculate_start_time()
@@ -74,12 +85,19 @@ class Deadline(object):
         return retval
 
 
-# A class encapsulating tracking of the duration of an operation.
-# Useful for cases where one wants to track how long something took.
 class Duration(object):
-    # Constructor
-    # @param start_now Specify whether the start time should start now, or wait until explicitly invoked
-    def __init__(self, start_now = False):
+    """A class encapsulating tracking of the duration of an operation.
+
+  Useful for cases where one wants to track how long something took.
+  """
+
+    def __init__(self, start_now: bool = False):
+        """Constructor.
+
+        Args:
+            start_now (bool, optional): specify whether the start time should
+                start now, or wait until explicitly invoked. Defaults to False.
+        """
         self.__start_time = None
 
         if start_now:
@@ -93,19 +111,29 @@ class Duration(object):
 
         return retval
 
-    # Return the start time
-    # @returns the start time
     @property
-    def start_time(self):
+    def start_time(self) -> float:
+        """Return the start time.
+
+        Returns:
+            float: Return the start time.
+        """
         return self.__start_time
 
-    # Start the duration, if not already started
-    def start(self):
+    def start(self) -> float:
+        """Start the duration, if not already started.
+
+        Returns:
+            float: start time.
+        """
         return self.__calculate_start_time()
 
-    # Get the time since the start time
-    # @returns The time in seconds
-    def get_elapsed_seconds(self):
+    def get_elapsed_seconds(self) -> float:
+        """Get the time since the start time
+
+        Returns:
+            float: The time in seconds.
+        """
         retval = None
 
         self.__calculate_start_time()
@@ -116,4 +144,3 @@ class Duration(object):
         retval = diff.seconds
 
         return retval
-

--- a/silk/tools/otns_manager.py
+++ b/silk/tools/otns_manager.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """OTNS integration manager.
 
 This class manages the communication between a Silk test case and the OTNS
@@ -44,1097 +43,1033 @@ SERVER_PORT = 9000
 
 
 class RegexType(enum.Enum):
-  """Regular expression collections.
-  """
-  START_WPANTUND_REQ = r"Starting wpantund .* ip netns exec"
-  START_WPANTUND_RES = r"wpantund\[(\d+)\]: Starting wpantund"
-  STOP_WPANTUND_REQ = r"sudo ip netns del"
-  GET_EXTADDR_REQ = r"getprop -v NCP:ExtendedAddress"
-  GET_EXTADDR_RES = r"\[stdout\] \[([A-Fa-f0-9]{16})\]"
-  STATUS = r"wpantund\[(\d+)\]: NCP => .*\[OTNS\] ([\w\d]+=[A-Fa-f0-9,rsdn]+)"
-  EXTADDR_STATUS = r"extaddr=([A-Fa-f0-9]{16})"
-  ROLE_STATUS = r"role=([0-4])"
-  CHILD_ADDED_STATUS = r"child_added=([A-Fa-f0-9]{16})"
-  CHILD_REMOVED_STATUS = r"child_removed=([A-Fa-f0-9]{16})"
-  ROUTER_ADDED_STATUS = r"router_added=([A-Fa-f0-9]{16})"
-  ROUTER_REMOVED_STATUS = r"router_removed=([A-Fa-f0-9]{16})"
-  NCP_VERSION = r"NCP is running \"(.*)\""
+    """Regular expression collections.
+    """
+    START_WPANTUND_REQ = r"Starting wpantund .* ip netns exec"
+    START_WPANTUND_RES = r"wpantund\[(\d+)\]: Starting wpantund"
+    STOP_WPANTUND_REQ = r"sudo ip netns del"
+    GET_EXTADDR_REQ = r"getprop -v NCP:ExtendedAddress"
+    GET_EXTADDR_RES = r"\[stdout\] \[([A-Fa-f0-9]{16})\]"
+    STATUS = r"wpantund\[(\d+)\]: NCP => .*\[OTNS\] ([\w\d]+=[A-Fa-f0-9,rsdn]+)"
+    EXTADDR_STATUS = r"extaddr=([A-Fa-f0-9]{16})"
+    ROLE_STATUS = r"role=([0-4])"
+    CHILD_ADDED_STATUS = r"child_added=([A-Fa-f0-9]{16})"
+    CHILD_REMOVED_STATUS = r"child_removed=([A-Fa-f0-9]{16})"
+    ROUTER_ADDED_STATUS = r"router_added=([A-Fa-f0-9]{16})"
+    ROUTER_REMOVED_STATUS = r"router_removed=([A-Fa-f0-9]{16})"
+    NCP_VERSION = r"NCP is running \"(.*)\""
 
 
 class EventType(enum.Enum):
-  ALARM_FIRED = 0
-  RADIO_RECEIVED = 1
-  UART_WRITE = 2
-  RADIO_SPINEL_WRITE = 3
-  OTNS_STATUS_PUSH = 5
-  DATA_MAX_SIZE = 1024
+    ALARM_FIRED = 0
+    RADIO_RECEIVED = 1
+    UART_WRITE = 2
+    RADIO_SPINEL_WRITE = 3
+    OTNS_STATUS_PUSH = 5
+    DATA_MAX_SIZE = 1024
 
 
 class RoleType(enum.Enum):
-  DISABLED = 0
-  DETACHED = 1
-  CHILD = 2
-  ROUTER = 3
-  LEADER = 4
+    DISABLED = 0
+    DETACHED = 1
+    CHILD = 2
+    ROUTER = 3
+    LEADER = 4
 
 
 class GRpcClient:
-  """gRPC client that interacts with OTNS server's gRPC services.
+    """gRPC client that interacts with OTNS server's gRPC services.
 
-  Attributes:
-    server_addr (str): address of the gRPC server.
-    channel (grpc.Channel): gRPC channel.
-    stub (VisualizeGrpcServiceStub): gRPC stub that references the
-      visualization gRPC service.
-    logger (Logger): logger for the client class.
-  """
-
-  def __init__(self, server_addr: str, logger: logging.Logger):
-    """Initializes a gRPC client.
-
-    Args:
-      server_addr (str): the address of the gRPC server.
-      logger (logging.Logger): logger for the class.
+    Attributes:
+        server_addr (str): address of the gRPC server.
+        channel (grpc.Channel): gRPC channel.
+        stub (VisualizeGrpcServiceStub): gRPC stub that references the visualization gRPC service.
+        logger (Logger): logger for the client class.
     """
-    logger.debug(f"Starting gRPC client with address {server_addr}")
-    self.server_addr = server_addr
-    self.channel = grpc.insecure_channel(self.server_addr)
-    self.stub = visualize_grpc_pb2_grpc.VisualizeGrpcServiceStub(self.channel)
-    self.logger = logger
 
-  def wait_for_channel_ready(self, timeout: int=10):
-    """Blocking method that waits for the gRPC channel to be ready.
+    def __init__(self, server_addr: str, logger: logging.Logger):
+        """Initializes a gRPC client.
 
-    Args:
-      timeout (int, optional): wait timeout. Defaults to 10.
-    """
-    grpc.channel_ready_future(self.channel).result(timeout=timeout)
+        Args:
+            server_addr (str): the address of the gRPC server.
+            logger (logging.Logger): logger for the class.
+        """
+        logger.debug(f"Starting gRPC client with address {server_addr}")
+        self.server_addr = server_addr
+        self.channel = grpc.insecure_channel(self.server_addr)
+        self.stub = visualize_grpc_pb2_grpc.VisualizeGrpcServiceStub(self.channel)
+        self.logger = logger
 
-  def _send_command(self, command: str):
-    """Send a Command gRPC request.
+    def wait_for_channel_ready(self, timeout: int = 10):
+        """Blocking method that waits for the gRPC channel to be ready.
 
-    Args:
-      command (str): command content.
-    """
-    self.logger.info(f"Sending cmd: {command}")
-    response = self.stub.Command(
-        visualize_grpc_pb2.CommandRequest(command=command))
-    self.logger.info(f"Sent cmd: {command}, resp: {response}".rstrip("\n"))
+        Args:
+            timeout (int, optional): wait timeout. Defaults to 10.
+        """
+        grpc.channel_ready_future(self.channel).result(timeout=timeout)
 
-  def set_title(self, title: str, x=0, y=20, font_size=20):
-    """Send test title to OTNS.
+    def _send_command(self, command: str):
+        """Send a Command gRPC request.
 
-    Args:
-      title (str): test title.
-      x (int): x position of title.
-      y (int): y position of title.
-      font_size (int): font size of title.
-    """
-    self._send_command(f"title \"{title}\" x {x} y {y} fs {font_size}")
+        Args:
+            command (str): command content.
+        """
+        self.logger.info(f"Sending cmd: {command}")
+        response = self.stub.Command(visualize_grpc_pb2.CommandRequest(command=command))
+        self.logger.info(f"Sent cmd: {command}, resp: {response}".rstrip("\n"))
 
-  def set_speed(self, speed: float):
-    """Send test replay speed to OTNS.
+    def set_title(self, title: str, x=0, y=20, font_size=20):
+        """Send test title to OTNS.
 
-    Args:
-      speed (float): test replay speed.
-    """
-    self._send_command(f"speed {speed}")
+        Args:
+            title (str): test title.
+            x (int): x position of title.
+            y (int): y position of title.
+            font_size (int): font size of title.
+        """
+        self._send_command(f"title \"{title}\" x {x} y {y} fs {font_size}")
 
-  def set_netinfo(self, version: str=None, commit: str=None):
-    """Set OTNS netinfo.
+    def set_speed(self, speed: float):
+        """Send test replay speed to OTNS.
 
-    Args:
-      version (str, optional): version string. Default to None.
-      commit (str, optional): commit string. Default to None.
-    """
-    version_clause = f"version \"{version}\"" if version is not None else ""
-    commit_clause = f"commit \"{commit}\"" if commit is not None else ""
-    self._send_command(f"netinfo {version_clause} {commit_clause} real y")
+        Args:
+            speed (float): test replay speed.
+        """
+        self._send_command(f"speed {speed}")
 
-  def add_node(self, x: int, y: int, node_id: int):
-    """Sends an add node request.
+    def set_netinfo(self, version: str = None, commit: str = None):
+        """Set OTNS netinfo.
 
-    Args:
-      x (int): x coordinate of the new node.
-      y (int): y coordinate of the new node.
-      node_id (int): node ID of the new node.
-    """
-    self._send_command(f"add router x {x} y {y} id {node_id}")
+        Args:
+            version (str, optional): version string. Default to None.
+            commit (str, optional): commit string. Default to None.
+        """
+        version_clause = f"version \"{version}\"" if version is not None else ""
+        commit_clause = f"commit \"{commit}\"" if commit is not None else ""
+        self._send_command(f"netinfo {version_clause} {commit_clause} real y")
 
-  def move_node(self, node_id: int, x: int, y: int):
-    """Sends a move node request async.
+    def add_node(self, x: int, y: int, node_id: int):
+        """Sends an add node request.
 
-    Args:
-      node_id (int): node ID of the node to be moved.
-      x (int): new x coordinate of the node.
-      y (int): new y coordianate of the node.
-    """
-    self._send_command(f"move {node_id} {x} {y}")
+        Args:
+            x (int): x coordinate of the new node.
+            y (int): y coordinate of the new node.
+            node_id (int): node ID of the new node.
+        """
+        self._send_command(f"add router x {x} y {y} id {node_id}")
 
-  def delete_node(self, node_id: int):
-    """Sends a delete node request.
+    def move_node(self, node_id: int, x: int, y: int):
+        """Sends a move node request async.
+
+        Args:
+            node_id (int): node ID of the node to be moved.
+            x (int): new x coordinate of the node.
+            y (int): new y coordianate of the node.
+        """
+        self._send_command(f"move {node_id} {x} {y}")
+
+    def delete_node(self, node_id: int):
+        """Sends a delete node request.
 
     Args:
       node_id (int): node ID of the node to be deleted.
     """
-    self._send_command(f"del {node_id}")
+        self._send_command(f"del {node_id}")
 
 
 class Event:
-  """Class that represents an event.
+    """Class that represents an event.
 
-  Class represents a UDP message that OTNS interprets as an event.
+    Class represents a UDP message that OTNS interprets as an event.
 
-  Attributes:
-    delay (int): alarm delay in ns.
-    event (EventType): type of the event.
-    data (bytes): message data of the event.
-    length (int): length of data.
-  """
-
-  def __init__(self, data: bytes, event: EventType, delay=0):
-    """Initializes an event.
-
-    Args:
-      data (bytes): data bytes.
-      event (EventType): type of the event.
-      delay (int, optional): alarm delay in us. Defaults to 0
-        for non-alarm events.
+    Attributes:
+        delay (int): alarm delay in ns.
+        event (EventType): type of the event.
+        data (bytes): message data of the event.
+        length (int): length of data.
     """
-    self.delay = delay
-    self.event = event.value
-    self.data = data
-    self.length = len(self.data)
 
-  @staticmethod
-  def status_event(message: str):
-    """Creates a status event.
+    def __init__(self, data: bytes, event: EventType, delay=0):
+        """Initializes an event.
 
-    Args:
-      message (str): status event message string.
+        Args:
+            data (bytes): data bytes.
+            event (EventType): type of the event.
+            delay (int, optional): alarm delay in us. Defaults to 0 for non-alarm events.
+        """
+        self.delay = delay
+        self.event = event.value
+        self.data = data
+        self.length = len(self.data)
 
-    Returns:
-      Event: a status event object with the message encoded into bytes.
-    """
-    return Event(data=message.encode("ascii"),
-                 event=EventType.OTNS_STATUS_PUSH)
+    @staticmethod
+    def status_event(message: str):
+        """Creates a status event.
 
-  @staticmethod
-  def alarm_event(delay=1):
-    """Creates an alarm event.
+        Args:
+            message (str): status event message string.
 
-    Args:
-      delay (int, optional): alarm delay in us. Defaults to 1.
+        Returns:
+            Event: a status event object with the message encoded into bytes.
+        """
+        return Event(data=message.encode("ascii"), event=EventType.OTNS_STATUS_PUSH)
 
-    Returns:
-      Event: an alarm event object with empty data.
-    """
-    return Event(data=b"", delay=delay, event=EventType.ALARM_FIRED)
+    @staticmethod
+    def alarm_event(delay=1):
+        """Creates an alarm event.
 
-  def to_bytes(self) -> bytes:
-    """Convert the event to bytes, to be sent as a UDP message.
+        Args:
+            delay (int, optional): alarm delay in us. Defaults to 1.
 
-    The message format follows the OTNS event UDP format.
-    <: little-endian, standard size, no alignment.
-    Q: unsigned long long: 8 bytes. Corresponding to event's
-      delay field in uint64_t.
-    B: unsigned char: 1 byte. Corresponding to event's event field in uint8_t.
-    H: unsigned short: 2 bytes. Corresponding to event's data
-      length field in uint16_t.
-    The data follows the header as defined above.
+        Returns:
+            Event: an alarm event object with empty data.
+        """
+        return Event(data=b"", delay=delay, event=EventType.ALARM_FIRED)
 
-    Returns:
-      bytes: converted message bytes.
-    """
-    return struct.pack("<QBH", self.delay, self.event, self.length) + self.data
+    def to_bytes(self) -> bytes:
+        """Convert the event to bytes, to be sent as a UDP message.
+
+        The message format follows the OTNS event UDP format.
+        <: little-endian, standard size, no alignment.
+        Q: unsigned long long: 8 bytes. Corresponding to event's
+        delay field in uint64_t.
+        B: unsigned char: 1 byte. Corresponding to event's event field in uint8_t.
+        H: unsigned short: 2 bytes. Corresponding to event's data
+        length field in uint16_t.
+        The data follows the header as defined above.
+
+        Returns:
+            bytes: converted message bytes.
+        """
+        return struct.pack("<QBH", self.delay, self.event, self.length) + self.data
 
 
 class OtnsNode(object):
-  """Class that represents a Thread network node for the purpose of OTNS integration.
+    """Class that represents a Thread network node for OTNS integration.
 
-  Attributes:
-    node_id (int): ID of the node.
-    vis_x (int): visualization x coordinate.
-    vis_y (int): visualization y coordinate.
-    sock (socket): UDP socket to send message from.
-    source_addr (str, int): UDP source address.
-    dest_addr (str, int): UDP destination address.
+    Attributes:
+        node_id (int): ID of the node.
+        vis_x (int): visualization x coordinate.
+        vis_y (int): visualization y coordinate.
+        sock (socket): UDP socket to send message from.
+        source_addr (str, int): UDP source address.
+        dest_addr (str, int): UDP destination address.
 
-    grpc_client (GRpcClient): gRPC client instance from the manager.
-    logger (logging.Logger): logger for the node.
-    node_on_otns (bool): if the node has been reported to OTNS.
+        grpc_client (GRpcClient): gRPC client instance from the manager.
+        logger (logging.Logger): logger for the node.
+        node_on_otns (bool): if the node has been reported to OTNS.
 
-    extaddr(int): extended address of the node in network.
-    role(RoleType): role of the node in network.
-    children (List[int]): extended addresses of children.
-    neighbors (List[int]): extended addresses of neighbors.
-  """
-
-  def __init__(self, node_id: int, vis_x: int, vis_y: int,
-               local_host: str, server_host: str, server_port: int,
-               grpc_client: GRpcClient, logger: logging.Logger):
-    """Initialize a node.
-
-    Args:
-      node_id (int): ID of the node.
-      vis_x (int): visualization x coordinate.
-      vis_y (int): visualization y coordinate.
-      local_host (str): host address of this machine.
-      server_host (str): host address of the OTNS dispatcher.
-      server_port (int): port number of the OTNS dispatcher.
-      grpc_client (GRpcClient): gRPC client instance from the manager.
-      logger (logging.Logger): logger for the node.
+        extaddr(int): extended address of the node in network.
+        role(RoleType): role of the node in network.
+        children (List[int]): extended addresses of children.
+        neighbors (List[int]): extended addresses of neighbors.
     """
-    assert node_id > 0
 
-    self.node_id = node_id
-    self.logger = logger
+    def __init__(self, node_id: int, vis_x: int, vis_y: int, local_host: str, server_host: str, server_port: int,
+                 grpc_client: GRpcClient, logger: logging.Logger):
+        """Initialize a node.
 
-    self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    self.source_addr = (local_host, server_port + node_id)
-    self.dest_addr = (server_host, server_port)
-    self.logger.debug(
-        "Node {:d} socket from {:s}:{:d} to {:s}:{:d}".format(
-            self.node_id,
-            self.source_addr[0],
-            self.source_addr[1],
-            self.dest_addr[0],
-            self.dest_addr[1]))
-    self.sock.bind(self.source_addr)
+        Args:
+            node_id (int): ID of the node.
+            vis_x (int): visualization x coordinate.
+            vis_y (int): visualization y coordinate.
+            local_host (str): host address of this machine.
+            server_host (str): host address of the OTNS dispatcher.
+            server_port (int): port number of the OTNS dispatcher.
+            grpc_client (GRpcClient): gRPC client instance from the manager.
+            logger (logging.Logger): logger for the node.
+        """
+        assert node_id > 0
 
-    self.vis_x = vis_x
-    self.vis_y = vis_y
-    self.grpc_client = grpc_client
+        self.node_id = node_id
+        self.logger = logger
 
-    self.extaddr = node_id
-    self.role = RoleType.DISABLED
-    self.children = set()
-    self.neighbors = set()
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.source_addr = (local_host, server_port + node_id)
+        self.dest_addr = (server_host, server_port)
+        self.logger.debug("Node {:d} socket from {:s}:{:d} to {:s}:{:d}".format(self.node_id, self.source_addr[0],
+                                                                                self.source_addr[1], self.dest_addr[0],
+                                                                                self.dest_addr[1]))
+        self.sock.bind(self.source_addr)
 
-    self.node_on_otns = False
+        self.vis_x = vis_x
+        self.vis_y = vis_y
+        self.grpc_client = grpc_client
 
-  def bind_socket(self):
-    """Bind socket to the address.
-    """
-    self.sock.bind(self.source_addr)
+        self.extaddr = node_id
+        self.role = RoleType.DISABLED
+        self.children = set()
+        self.neighbors = set()
 
-  def close_socket(self):
-    """Close the node's socket connection.
-    """
-    self.sock.close()
+        self.node_on_otns = False
 
-  def send_event(self, event_packet: bytes):
-    """Send event bytes packet.
+    def bind_socket(self):
+        """Bind socket to the address.
+        """
+        self.sock.bind(self.source_addr)
 
-    Args:
-      event_packet (bytes): pacakged event content in bytes.
-    """
-    self.sock.sendto(event_packet, self.dest_addr)
+    def close_socket(self):
+        """Close the node's socket connection.
+        """
+        self.sock.close()
 
-  def send_extaddr_event(self):
-    """Send extaddr event.
-    """
-    event = Event.status_event(f"extaddr={self.extaddr:016x}")
-    self.logger.debug(
-        f"Node {self.node_id} sending extaddr={self.extaddr:016x}")
-    self.send_event(event.to_bytes())
+    def send_event(self, event_packet: bytes):
+        """Send event bytes packet.
 
-  def send_role_event(self):
-    """Send role event.
-    """
-    event = Event.status_event(f"role={self.role.value:1d}")
-    self.logger.debug(f"Node {self.node_id} sending role={self.role.value:1d}")
-    self.send_event(event.to_bytes())
+        Args:
+            event_packet (bytes): pacakged event content in bytes.
+        """
+        self.sock.sendto(event_packet, self.dest_addr)
 
-  def send_child_added_event(self, child_addr: int):
-    """Send child added event.
+    def send_extaddr_event(self):
+        """Send extaddr event.
+        """
+        event = Event.status_event(f"extaddr={self.extaddr:016x}")
+        self.logger.debug(f"Node {self.node_id} sending extaddr={self.extaddr:016x}")
+        self.send_event(event.to_bytes())
 
-    Args:
-      child_addr (str): extended address of the child
-        that is added to this node.
-    """
-    event = Event.status_event(f"child_added={child_addr:016x}")
-    self.send_event(event.to_bytes())
+    def send_role_event(self):
+        """Send role event.
+        """
+        event = Event.status_event(f"role={self.role.value:1d}")
+        self.logger.debug(f"Node {self.node_id} sending role={self.role.value:1d}")
+        self.send_event(event.to_bytes())
 
-  def send_child_removed_event(self, child_addr: int):
-    """Send child removed event.
+    def send_child_added_event(self, child_addr: int):
+        """Send child added event.
 
-    Args:
-      child_addr (str): extended address of the child
-        that is removed from this node.
-    """
-    event = Event.status_event(f"child_removed={child_addr:016x}")
-    self.send_event(event.to_bytes())
+        Args:
+            child_addr (str): extended address of the child that is added to this node.
+        """
+        event = Event.status_event(f"child_added={child_addr:016x}")
+        self.send_event(event.to_bytes())
 
-  def send_router_added_event(self, router_addr: int):
-    """Send router added event.
+    def send_child_removed_event(self, child_addr: int):
+        """Send child removed event.
 
-    Args:
-      router_addr (str): extended address of the router
-        that is added to  the neighbor list of this node.
-    """
-    event = Event.status_event(f"router_added={router_addr:016x}")
-    self.send_event(event.to_bytes())
+        Args:
+            child_addr (str): extended address of the child that is removed from this node.
+        """
+        event = Event.status_event(f"child_removed={child_addr:016x}")
+        self.send_event(event.to_bytes())
 
-  def send_router_removed_event(self, router_addr: int):
-    """Send router removed event.
+    def send_router_added_event(self, router_addr: int):
+        """Send router added event.
 
-    Args:
-      router_addr (str): extended address of the router
-        that is removed from the neighbor list of this node.
-    """
-    event = Event.status_event(f"router_removed={router_addr:016x}")
-    self.send_event(event.to_bytes())
+        Args:
+            router_addr (str): extended address of the router that is added to  the neighbor list of this node.
+        """
+        event = Event.status_event(f"router_added={router_addr:016x}")
+        self.send_event(event.to_bytes())
 
-  def update_extaddr(self, extaddr: int):
-    """Update the node's extended address.
+    def send_router_removed_event(self, router_addr: int):
+        """Send router removed event.
 
-    Args:
-      extaddr (int): new extended address of the node.
-    """
-    if extaddr != self.extaddr:
-      self.extaddr = extaddr
-      self.send_extaddr_event()
+        Args:
+            router_addr (str): extended address of the router that is removed from the neighbor list of this node.
+        """
+        event = Event.status_event(f"router_removed={router_addr:016x}")
+        self.send_event(event.to_bytes())
 
-  def update_role(self, role: RoleType):
-    """Update the node's role.
+    def update_extaddr(self, extaddr: int):
+        """Update the node's extended address.
 
-    Args:
-      role (RoleType): new role of the node.
-    """
-    if role != self.role:
-      self.role = role
-      self.send_role_event()
+        Args:
+            extaddr (int): new extended address of the node.
+        """
+        if extaddr != self.extaddr:
+            self.extaddr = extaddr
+            self.send_extaddr_event()
 
-  def add_child(self, child_addr: int):
-    """Add a node as a child of this node.
+    def update_role(self, role: RoleType):
+        """Update the node's role.
 
-    Args:
-      child_addr (int): extended address of the child to add.
-    """
-    if child_addr not in self.children:
-      self.children.add(child_addr)
-      self.send_child_added_event(child_addr)
+        Args:
+            role (RoleType): new role of the node.
+        """
+        if role != self.role:
+            self.role = role
+            self.send_role_event()
 
-  def remove_child(self, child_addr: int):
-    """Remove a child node of this node.
+    def add_child(self, child_addr: int):
+        """Add a node as a child of this node.
 
-    Args:
-      child_addr (int): extended address of the child to remove.
-    """
-    if child_addr in self.children:
-      self.children.remove(child_addr)
-      self.send_child_removed_event(child_addr)
+        Args:
+            child_addr (int): extended address of the child to add.
+        """
+        if child_addr not in self.children:
+            self.children.add(child_addr)
+            self.send_child_added_event(child_addr)
 
-  def add_router(self, router_addr: int):
-    """Add a router node as a neighbor of this node.
+    def remove_child(self, child_addr: int):
+        """Remove a child node of this node.
 
-    Args:
-      router_addr (int): extended address of the router to add.
-    """
-    if router_addr not in self.neighbors:
-      self.neighbors.add(router_addr)
-      self.send_router_added_event(router_addr)
+        Args:
+            child_addr (int): extended address of the child to remove.
+        """
+        if child_addr in self.children:
+            self.children.remove(child_addr)
+            self.send_child_removed_event(child_addr)
 
-  def remove_router(self, router_addr: int):
-    """Remove a child node of this node.
+    def add_router(self, router_addr: int):
+        """Add a router node as a neighbor of this node.
 
-    Args:
-      router_addr (int): extended address of the router to remove.
-    """
-    if router_addr in self.neighbors:
-      self.neighbors.remove(router_addr)
-      self.send_router_removed_event(router_addr)
+        Args:
+            router_addr (int): extended address of the router to add.
+        """
+        if router_addr not in self.neighbors:
+            self.neighbors.add(router_addr)
+            self.send_router_added_event(router_addr)
 
-  def create_otns_node(self):
-    """Call gRPC client to create a node on server for itself.
-    """
-    if self.node_on_otns:
-      self.logger.debug(
-          f"Node {self.node_id} already on OTNS while trying to create")
-      return
-    self.logger.debug(
-        f"Adding node {self.node_id} to OTNS at ({self.vis_x},{self.vis_y})")
-    self.grpc_client.add_node(self.vis_x, self.vis_y, self.node_id)
-    self.send_extaddr_event()
-    self.node_on_otns = True
+    def remove_router(self, router_addr: int):
+        """Remove a child node of this node.
 
-  def delete_otns_node(self):
-    """Call gRPC client to remove the node on server for itself.
-    """
-    if not self.node_on_otns:
-      self.logger.debug(
-          f"Node {self.node_id} not on OTNS while trying to delete")
-      return
-    self.logger.debug(f"Deleting node {self.node_id} on OTNS")
-    self.grpc_client.delete_node(self.node_id)
-    self.node_on_otns = False
+        Args:
+            router_addr (int): extended address of the router to remove.
+        """
+        if router_addr in self.neighbors:
+            self.neighbors.remove(router_addr)
+            self.send_router_removed_event(router_addr)
 
-  def update_otns_vis_position(self):
-    """Call gRPC client to update the node's visualization position.
-    """
-    self.logger.debug(
-        f"Moving node {self.node_id} to OTNS at ({self.vis_x},{self.vis_y})")
-    self.grpc_client.move_node(self.node_id, self.vis_x, self.vis_y)
+    def create_otns_node(self):
+        """Call gRPC client to create a node on server for itself.
+        """
+        if self.node_on_otns:
+            self.logger.debug(f"Node {self.node_id} already on OTNS while trying to create")
+            return
+        self.logger.debug(f"Adding node {self.node_id} to OTNS at ({self.vis_x},{self.vis_y})")
+        self.grpc_client.add_node(self.vis_x, self.vis_y, self.node_id)
+        self.send_extaddr_event()
+        self.node_on_otns = True
 
-  def update_vis_position(self, x: int, y: int):
-    if x != self.vis_x or y != self.vis_y:
-      self.vis_x = x
-      self.vis_y = y
-      self.update_otns_vis_position()
+    def delete_otns_node(self):
+        """Call gRPC client to remove the node on server for itself.
+        """
+        if not self.node_on_otns:
+            self.logger.debug(f"Node {self.node_id} not on OTNS while trying to delete")
+            return
+        self.logger.debug(f"Deleting node {self.node_id} on OTNS")
+        self.grpc_client.delete_node(self.node_id)
+        self.node_on_otns = False
+
+    def update_otns_vis_position(self):
+        """Call gRPC client to update the node's visualization position.
+        """
+        self.logger.debug(f"Moving node {self.node_id} to OTNS at ({self.vis_x},{self.vis_y})")
+        self.grpc_client.move_node(self.node_id, self.vis_x, self.vis_y)
+
+    def update_vis_position(self, x: int, y: int):
+        if x != self.vis_x or y != self.vis_y:
+            self.vis_x = x
+            self.vis_y = y
+            self.update_otns_vis_position()
 
 
 class WpantundOtnsMonitor(signal.Subscriber):
-  """OTNS log monitor for wpantund process logs.
+    """OTNS log monitor for wpantund process logs.
 
-  Attributes:
-    node (OtnsNode): OTNS node instance that handles UDP messaging.
-    otns_manager (OtnsManager): OTNS manager instance the monitor was
-      created from.
-  """
-
-  node = None
-  otns_manager = None
-
-  def process_log_line(self, line: str):
-    """Process a single line of wpantund log.
-
-    Args:
-        line (str): line of log to process.
+    Attributes:
+        node (OtnsNode): OTNS node instance that handles UDP messaging.
+        otns_manager (OtnsManager): OTNS manager instance the monitor was created from.
     """
-    if self.otns_manager:
-      self.otns_manager.update_status(self.node, line)
 
-  def subscribeHandle(self, sender, **kwargs):
-    """Handle messages from Publisher, a wpantund process.
+    node = None
+    otns_manager = None
 
-    Args:
-      sender (singal.Publisher): publisher of signal.
-      **kwargs (str): published signal.
-    """
-    line = kwargs["line"]
-    self.process_log_line(line)
+    def process_log_line(self, line: str):
+        """Process a single line of wpantund log.
+
+        Args:
+            line (str): line of log to process.
+        """
+        if self.otns_manager:
+            self.otns_manager.update_status(self.node, line)
+
+    def subscribe_handle(self, sender, **kwargs):
+        """Handle messages from Publisher, a wpantund process.
+
+        Args:
+            sender (singal.Publisher): publisher of signal.
+            **kwargs (str): published signal.
+        """
+        line = kwargs["line"]
+        self.process_log_line(line)
 
 
 class OtnsNodeSummary(object):
-  """OTNS history summary for a node.
+    """OTNS history summary for a node.
 
-  Attributes:
-    node_id (int): ID of the node.
-    extaddr_history (List[Tuple[datetime, int]]): history of extaddr.
-    role_history (List[Tuple[datetime, RoleType]]): history of the
-      node's role.
-    children_history (List[Tuple[datetime, bool, int]]): history of the
-      node's children.
-    neighbors_history (List[Tuple[datetime, bool, int]]): history of the
-      node's neighbors.
-  """
-
-  def __init__(self, node_id: int):
-    """Initialize a summary object for an OTNS node.
-
-    Args:
-      node_id (int): ID of the node.
+    Attributes:
+        node_id (int): ID of the node.
+        extaddr_history (List[Tuple[datetime, int]]): history of extaddr.
+        role_history (List[Tuple[datetime, RoleType]]): history of the node's role.
+        children_history (List[Tuple[datetime, bool, int]]): history of the node's children.
+        neighbors_history (List[Tuple[datetime, bool, int]]): history of the node's neighbors.
     """
-    self.node_id = node_id
 
-    self.extaddr_history = []
-    self.role_history = []
-    self.children_history = []
-    self.neighbors_history = []
+    def __init__(self, node_id: int):
+        """Initialize a summary object for an OTNS node.
 
-  def extaddr_changed(self, extaddr: int, time=datetime.now()):
-    """Add an entry to the node's extended address history.
+        Args:
+            node_id (int): ID of the node.
+        """
+        self.node_id = node_id
 
-    Args:
-      extaddr (int): new extended address of node.
-      time (datetime.datetime, optional): time of the change. Defaults
-        to datetime.now().
+        self.extaddr_history = []
+        self.role_history = []
+        self.children_history = []
+        self.neighbors_history = []
+
+    def extaddr_changed(self, extaddr: int, time=datetime.now()):
+        """Add an entry to the node's extended address history.
+
+        Args:
+            extaddr (int): new extended address of node.
+            time (datetime.datetime, optional): time of the change. Defaults to datetime.now().
+        """
+        if not self.extaddr_history or self.extaddr_history[-1][1] != extaddr:
+            self.extaddr_history.append((time, extaddr))
+
+    def role_changed(self, role: RoleType, time=datetime.now()):
+        """Add an entry to the node's role history.
+
+        Args:
+            role (RoleType): new role of node.
+            time (datetime.datetime, optional): time of the change. Defaults to datetime.now().
+        """
+        if not self.role_history or self.role_history[-1][1] != role:
+            self.role_history.append((time, role))
+
+    def child_changed(self, added: bool, child: int, time=datetime.now()):
+        """Add an entry to the node's children history.
+
+        Args:
+            added (bool): True if the child is added; False if removed.
+            child (int): extended address of the child.
+            time (datetime.datetime, optional): time of the change. Defaults to datetime.now().
+        """
+        self.children_history.append((time, added, child))
+
+    def neighbor_changed(self, added: bool, neighbor: int, time=datetime.now()):
+        """Add an entry to the node's neighbors history.
+
+        Args:
+            added (bool): True if the neighbor is added; False if removed.
+            neighbor (int): extended address of the neighbor.
+            time (datetime.datetime, optional): time of the change. Defaults to datetime.now().
+        """
+        self.neighbors_history.append((time, added, neighbor))
+
+    def format_extaddr_history(self) -> List[Tuple[datetime, str]]:
+        """Format this summary's extaddr history and return the list.
+
+        Returns:
+            List[Tuple[datetime, str]]: list of extaddr history, in the format of a tuple containing
+                the time of the event and the formatted string.
+        """
+        return [(time, f"extaddr {extaddr:016x}") for time, extaddr in self.extaddr_history]
+
+    def format_role_history(self) -> List[Tuple[datetime, str]]:
+        """Format this summary's role history and return the list.
+
+        Returns:
+            List[Tuple[datetime, str]]: list of role history, in the format of a tuple containing
+                the time of the event and the formatted string.
+        """
+        return [(time, f"role {role.name}") for time, role in self.role_history]
+
+    def format_children_history(self, extaddr_map: Dict[int, int]) -> List[Tuple[datetime, str]]:
+        """Format this summary's children history and return the list.
+
+        Args:
+            extaddr_map (Dict[int, int]): table mapping extaddr to node ID.
+
+        Returns:
+            List[Tuple[datetime, str]]: list of children history, in the format of a tuple containing
+                the time of the event and the formatted string.
+        """
+        history = []
+        for time, added, child in self.children_history:
+            action = "added" if added else "removed"
+            if child in extaddr_map:
+                child_repr = f"{action} child node {extaddr_map[child]:d}"
+            else:
+                child_repr = f"{action} child extaddr {child:016x}"
+            history.append((time, f"{child_repr}"))
+        return history
+
+    def format_neighbors_history(self, extaddr_map: Dict[int, int]) -> List[Tuple[datetime, str]]:
+        """Format this summary's neighbors history and return the list.
+
+        Args:
+            extaddr_map (Dict[int, int]): table mapping extaddr to node ID.
+
+        Returns:
+            List[Tuple[datetime, str]]: list of neighbors history, in the format of a tuple containing
+                the time of the event and the formatted string.
     """
-    if not self.extaddr_history or self.extaddr_history[-1][1] != extaddr:
-      self.extaddr_history.append((time, extaddr))
+        history = []
+        for time, added, neighbor in self.neighbors_history:
+            action = "added" if added else "removed"
+            if neighbor in extaddr_map:
+                neighbor_repr = f"{action} neighbor node {extaddr_map[neighbor]}"
+            else:
+                neighbor_repr = f"{action} neighbor extaddr {neighbor:016x}"
+            history.append((time, f"{neighbor_repr}"))
+        return history
 
-  def role_changed(self, role: RoleType, time=datetime.now()):
-    """Add an entry to the node's role history.
+    def to_string(self, extaddr_map: Dict[int, int]) -> str:
+        """Generate summary string.
 
-    Args:
-      role (RoleType): new role of node.
-      time (datetime.datetime, optional): time of the change. Defaults
-        to datetime.now().
-    """
-    if not self.role_history or self.role_history[-1][1] != role:
-      self.role_history.append((time, role))
+        Args:
+            extaddr_map (Dict[int, int]): table mapping extaddr to node ID.
 
-  def child_changed(self, added: bool, child: int, time=datetime.now()):
-    """Add an entry to the node's children history.
+        Returns:
+            str: string representation of the summary.
+        """
+        lines = []
+        lines.append(f"OTNS Summary for node {self.node_id}")
 
-    Args:
-      added (bool): True if the child is added; False if removed.
-      child (int): extended address of the child.
-      time (datetime.datetime, optional): time of the change. Defaults
-        to datetime.now().
-    """
-    self.children_history.append((time, added, child))
+        if self.extaddr_history:
+            lines.append("Extended address changes:")
+            lines.extend([f"[{h[0].strftime(DATE_FORMAT)[:-3]}] {h[1]}" for h in self.format_extaddr_history()])
 
-  def neighbor_changed(self, added: bool, neighbor: int, time=datetime.now()):
-    """Add an entry to the node's neighbors history.
+        if self.role_history:
+            lines.append("Role changes:")
+            lines.extend([f"[{h[0].strftime(DATE_FORMAT)[:-3]}] {h[1]}" for h in self.format_role_history()])
 
-    Args:
-      added (bool): True if the neighbor is added; False if removed.
-      neighbor (int): extended address of the neighbor.
-      time (datetime.datetime, optional): time of the change. Defaults
-        to datetime.now().
-    """
-    self.neighbors_history.append((time, added, neighbor))
+        if self.children_history:
+            lines.append("Children changes:")
+            lines.extend(
+                [f"[{h[0].strftime(DATE_FORMAT)[:-3]}] {h[1]}" for h in self.format_children_history(extaddr_map)])
 
-  def format_extaddr_history(self) -> List[Tuple[datetime, str]]:
-    """Format this summary's extaddr history and return the list.
+        if self.neighbors_history:
+            lines.append("Neighbors changes:")
+            lines.extend(
+                [f"[{h[0].strftime(DATE_FORMAT)[:-3]}] {h[1]}" for h in self.format_neighbors_history(extaddr_map)])
 
-    Returns:
-      List[Tuple[datetime, str]]: list of extaddr history, in the format of a
-        tuple containing the time of the event and the formatted string.
-    """
-    return [(time, f"extaddr {extaddr:016x}")
-            for time, extaddr in self.extaddr_history]
+        return "\n".join(lines)
 
-  def format_role_history(self) -> List[Tuple[datetime, str]]:
-    """Format this summary's role history and return the list.
+    def to_log_list(self, extaddr_map: Dict[int, int]) -> List[Tuple[datetime, str]]:
+        """Generate summary logs list.
 
-    Returns:
-      List[Tuple[datetime, str]]: list of role history, in the format of a
-        tuple containing the time of the event and the formatted string.
-    """
-    return [(time, f"role {role.name}") for time, role in self.role_history]
+        Args:
+            extaddr_map (Dict[int, int]): table mapping extaddr to node ID.
 
-  def format_children_history(self,
-                              extaddr_map: Dict[int, int]
-                             ) -> List[Tuple[datetime, str]]:
-    """Format this summary's children history and return the list.
+        Returns:
+            List[Tuple[datetime, str]]: list of node's history, in the format of a tuple containing the time
+                of the event and the log-formatted string.
+        """
+        return (self.format_extaddr_history() + self.format_role_history() +
+                self.format_children_history(extaddr_map) + self.format_neighbors_history(extaddr_map))
 
-    Args:
-      extaddr_map (Dict[int, int]): table mapping extaddr to node ID.
-
-    Returns:
-      List[Tuple[datetime, str]]: list of children history, in the format
-        of a tuple containing the time of the event and the formatted string.
-    """
-    history = []
-    for time, added, child in self.children_history:
-      action = "added" if added else "removed"
-      if child in extaddr_map:
-        child_repr = f"{action} child node {extaddr_map[child]:d}"
-      else:
-        child_repr = f"{action} child extaddr {child:016x}"
-      history.append((time, f"{child_repr}"))
-    return history
-
-  def format_neighbors_history(self,
-                               extaddr_map: Dict[int, int]
-                              ) -> List[Tuple[datetime, str]]:
-    """Format this summary's neighbors history and return the list.
-
-    Args:
-      extaddr_map (Dict[int, int]): table mapping extaddr to node ID.
-
-    Returns:
-      List[Tuple[datetime, str]]: list of neighbors history, in the format
-        of a tuple containing the time of the event and the formatted string.
-    """
-    history = []
-    for time, added, neighbor in self.neighbors_history:
-      action = "added" if added else "removed"
-      if neighbor in extaddr_map:
-        neighbor_repr = f"{action} neighbor node {extaddr_map[neighbor]}"
-      else:
-        neighbor_repr = f"{action} neighbor extaddr {neighbor:016x}"
-      history.append((time, f"{neighbor_repr}"))
-    return history
-
-  def to_string(self, extaddr_map: Dict[int, int]) -> str:
-    """Generate summary string.
-
-    Args:
-      extaddr_map (Dict[int, int]): table mapping extaddr to node ID.
-
-    Returns:
-      str: string representation of the summary.
-    """
-    lines = []
-    lines.append(f"OTNS Summary for node {self.node_id}")
-
-    if self.extaddr_history:
-      lines.append("Extended address changes:")
-      lines.extend([f"[{h[0].strftime(DATE_FORMAT)[:-3]}] {h[1]}"
-                    for h in self.format_extaddr_history()])
-
-    if self.role_history:
-      lines.append("Role changes:")
-      lines.extend([f"[{h[0].strftime(DATE_FORMAT)[:-3]}] {h[1]}"
-                    for h in self.format_role_history()])
-
-    if self.children_history:
-      lines.append("Children changes:")
-      lines.extend([f"[{h[0].strftime(DATE_FORMAT)[:-3]}] {h[1]}"
-                    for h in self.format_children_history(extaddr_map)])
-
-    if self.neighbors_history:
-      lines.append("Neighbors changes:")
-      lines.extend([f"[{h[0].strftime(DATE_FORMAT)[:-3]}] {h[1]}"
-                    for h in self.format_neighbors_history(extaddr_map)])
-
-    return "\n".join(lines)
-
-  def to_log_list(self,
-                  extaddr_map: Dict[int, int]) -> List[Tuple[datetime, str]]:
-    """Generate summary logs list.
-
-    Args:
-      extaddr_map (Dict[int, int]): table mapping extaddr to node ID.
-
-    Returns:
-      List[Tuple[datetime, str]]: list of node's history, in the format
-        of a tuple containing the time of the event and the log-formatted
-        string.
-    """
-    return (self.format_extaddr_history() +
-            self.format_role_history() +
-            self.format_children_history(extaddr_map) +
-            self.format_neighbors_history(extaddr_map))
 
 class OtnsNodeSummaryCollection(object):
-  """A collection of OtnsNodeSummary that supports printing events
-    ordered by time.
-
-  Args:
-    collection (List[OtnsNodeSummary]): list of OtnsNodeSummary.
-  """
-
-  def __init__(self, collection: List[OtnsNodeSummary]):
-    self.collection = collection
-
-  def to_string(self, extaddr_map: Dict[int, int]) -> str:
-    """Generate summary string.
+    """A collection of OtnsNodeSummary that supports printing events ordered by time.
 
     Args:
-      extaddr_map (Dict[int, int]): table mapping extaddr to node ID.
-
-    Returns:
-      str: string representation of the summary.
+        collection (List[OtnsNodeSummary]): list of OtnsNodeSummary.
     """
-    events = []
-    for summary in self.collection:
-      node_events = summary.to_log_list(extaddr_map)
-      events.extend([(time, summary.node_id, string) for time, string in node_events])
-    events.sort(key=lambda event:event[0])
 
-    lines = []
-    lines.append("OTNS Summary")
+    def __init__(self, collection: List[OtnsNodeSummary]):
+        self.collection = collection
 
-    for event in events:
-      lines.append(
-          f"[{event[0].strftime(DATE_FORMAT)[:-3]}] node {event[1]}: {event[2]}")
+    def to_string(self, extaddr_map: Dict[int, int]) -> str:
+        """Generate summary string.
 
-    return "\n".join(lines)
+        Args:
+            extaddr_map (Dict[int, int]): table mapping extaddr to node ID.
 
-  def to_csv(self, extaddr_map: Dict[int, int]) -> pandas.DataFrame:
-    """Generate summary string in CSV format.
+        Returns:
+            str: string representation of the summary.
+        """
+        events = []
+        for summary in self.collection:
+            node_events = summary.to_log_list(extaddr_map)
+            events.extend([(time, summary.node_id, string) for time, string in node_events])
+        events.sort(key=lambda event: event[0])
 
-    Args:
-      extaddr_map (Dict[int, int]): table mapping extaddr to node ID.
+        lines = []
+        lines.append("OTNS Summary")
 
-    Returns:
-      pandas.DataFrame: DataFrame of events.
-    """
-    events = []
-    for summary in self.collection:
-      node_events = summary.to_log_list(extaddr_map)
-      events.extend(
-          [(time, summary.node_id, string) for time, string in node_events])
-    events.sort(key=lambda event:event[0])
+        for event in events:
+            lines.append(f"[{event[0].strftime(DATE_FORMAT)[:-3]}]" f" node {event[1]}: {event[2]}")
 
-    node_ids = sorted(list(extaddr_map.values()))
-    columns = [f"node{i:d}" for i in node_ids]
-    columns.insert(0, 'timestamp')
+        return "\n".join(lines)
 
-    for i, event in enumerate(events):
-      events[i] = {"timestamp" : event[0].strftime(DATE_FORMAT)[:-3],
-                   f"node{event[1]}" : event[2]}
+    def to_csv(self, extaddr_map: Dict[int, int]) -> pandas.DataFrame:
+        """Generate summary string in CSV format.
 
-    return pandas.DataFrame(events, columns=columns)
+        Args:
+            extaddr_map (Dict[int, int]): table mapping extaddr to node ID.
+
+        Returns:
+            pandas.DataFrame: DataFrame of events.
+        """
+        events = []
+        for summary in self.collection:
+            node_events = summary.to_log_list(extaddr_map)
+            events.extend([(time, summary.node_id, string) for time, string in node_events])
+        events.sort(key=lambda event: event[0])
+
+        node_ids = sorted(list(extaddr_map.values()))
+        columns = [f"node{i:d}" for i in node_ids]
+        columns.insert(0, "timestamp")
+
+        for i, event in enumerate(events):
+            events[i] = {"timestamp": event[0].strftime(DATE_FORMAT)[:-3], f"node{event[1]}": event[2]}
+
+        return pandas.DataFrame(events, columns=columns)
 
 
 class OtnsManager(object):
-  """OTNS communication manager for a test case.
+    """OTNS communication manager for a test case.
 
-  Attributes:
-    server_host (str): host address of OTNS dispatcher.
-    grpc_client (GRpcClient): OTNS gRPC client.
-    otns_node_map (Dict[ThreadDevBoard, OtnsNode]): map from device to
-      OTNS node.
-    otns_monitor_map (Dict[ThreadDevBoard, WpantundOtnsMonitor]): map from
-      device to OTNS monitor.
-    local_host (str): host of this local machine.
-    logger (Logger): logger for the manager class.
-    auto_layout (bool): if manager should auto layout node positions.
-    max_node_count (int): the maximum number of nodes ever managed by
-      this manager.
-    node_summaries (Dict[int, OtnsNodeSummary]): map from node ID to
-      OtnsNodeSummary instances.
-  """
-
-  def __init__(self, server_host: str, logger: logging.Logger):
-    """Initialize an OTNS manager.
-
-    Args:
-      server_host (str): host address of OTNS dispatcher.
-      logger (logging.Logger): logger for the manager.
+    Attributes:
+        server_host (str): host address of OTNS dispatcher.
+        grpc_client (GRpcClient): OTNS gRPC client.
+        otns_node_map (Dict[ThreadDevBoard, OtnsNode]): map from device to OTNS node.
+        otns_monitor_map (Dict[ThreadDevBoard, WpantundOtnsMonitor]): map from device to OTNS monitor.
+        local_host (str): host of this local machine.
+        logger (Logger): logger for the manager class.
+        auto_layout (bool): if manager should auto layout node positions.
+        max_node_count (int): the maximum number of nodes ever managed by this manager.
+        node_summaries (Dict[int, OtnsNodeSummary]): map from node ID to OtnsNodeSummary instances.
     """
-    self.server_host = server_host
-    self.grpc_client = GRpcClient(
-        server_addr=f"{server_host}:{GRPC_SERVER_PORT}",
-        logger=logger.getChild("gRPCClient"))
-    self.otns_node_map = {}
-    self.otns_monitor_map = {}
 
-    self.auto_layout = False
-    self.max_node_count = 0
-    self.node_summaries = {}
+    def __init__(self, server_host: str, logger: logging.Logger):
+        """Initialize an OTNS manager.
 
-    self.local_host = get_local_ip()
+        Args:
+            server_host (str): host address of OTNS dispatcher.
+            logger (logging.Logger): logger for the manager.
+        """
+        self.server_host = server_host
+        self.grpc_client = GRpcClient(server_addr=f"{server_host}:{GRPC_SERVER_PORT}",
+                                      logger=logger.getChild("gRPCClient"))
+        self.otns_node_map = {}
+        self.otns_monitor_map = {}
 
-    self.logger = logger
-    self.logger.info(
-        f"OTNS manager created, connect {self.local_host} to {server_host}.")
+        self.auto_layout = False
+        self.max_node_count = 0
+        self.node_summaries = {}
 
-  def wait_for_grpc_channel_ready(self, timeout: int=10):
-    """Blocking method that waits for the gRPC channel to be ready.
+        self.local_host = get_local_ip()
 
-    Args:
-      timeout (int, optional): wait timeout. Defaults to 10.
-    """
-    self.grpc_client.wait_for_channel_ready(timeout)
+        self.logger = logger
+        self.logger.info(f"OTNS manager created, connect {self.local_host} to {server_host}.")
 
-  def set_test_title(self, title: str):
-    """Set title of the test case.
+    def wait_for_grpc_channel_ready(self, timeout: int = 10):
+        """Blocking method that waits for the gRPC channel to be ready.
 
-    Args:
-      title (str): title of the test case.
-    """
-    self.grpc_client.set_title(title)
+        Args:
+            timeout (int, optional): wait timeout. Defaults to 10.
+        """
+        self.grpc_client.wait_for_channel_ready(timeout)
 
-  def set_replay_speed(self, speed: float):
-    """Set speed of the replaying test log.
+    def set_test_title(self, title: str):
+        """Set title of the test case.
 
-    Args:
-      speed (float): speed of the replaying test log.
-    """
-    self.grpc_client.set_speed(speed)
+        Args:
+            title (str): title of the test case.
+        """
+        self.grpc_client.set_title(title)
 
-  def add_device(self, device: HwModule) -> OtnsNode:
-    """Add a hardware module to OTNS manager.
+    def set_replay_speed(self, speed: float):
+        """Set speed of the replaying test log.
 
-    Args:
-      device (HwModule): hardware device to add.
+        Args:
+            speed (float): speed of the replaying test log.
+        """
+        self.grpc_client.set_speed(speed)
 
-    Returns:
-      (OtnsNode): the OTNS node created from the device.
-    """
-    try:
-      vis_x, vis_y = device.get_otns_vis_position()
-    except ValueError:
-      vis_x, vis_y = device.get_otns_vis_layout_center()
-      self.auto_layout = True
+    def add_device(self, device: HwModule) -> OtnsNode:
+        """Add a hardware module to OTNS manager.
 
-    node_id = device.get_otns_vis_node_id()
-    otns_node = OtnsNode(
-        node_id=node_id,
-        vis_x=vis_x,
-        vis_y=vis_y,
-        local_host=self.local_host,
-        server_host=self.server_host,
-        server_port=SERVER_PORT,
-        grpc_client=self.grpc_client,
-        logger=self.logger.getChild(f"OtnsNode{node_id}"))
-    self.logger.debug(f"Adding new node {node_id} to OTNS")
-    otns_node.create_otns_node()
-    return otns_node
+        Args:
+            device (HwModule): hardware device to add.
 
-  def add_node(self, node: ThreadDevBoard):
-    """Add a node to OTNS visualization.
+        Returns:
+            (OtnsNode): the OTNS node created from the device.
+        """
+        try:
+            vis_x, vis_y = device.get_otns_vis_position()
+        except ValueError:
+            vis_x, vis_y = device.get_otns_vis_layout_center()
+            self.auto_layout = True
 
-    Args:
-      node (ThreadDevBoard): node to add, with dev board properties.
-    """
-    assert isinstance(node.device, HwModule), (
-        "Adding non HwModule node to OTNS manager.")
+        node_id = device.get_otns_vis_node_id()
+        otns_node = OtnsNode(node_id=node_id,
+                             vis_x=vis_x,
+                             vis_y=vis_y,
+                             local_host=self.local_host,
+                             server_host=self.server_host,
+                             server_port=SERVER_PORT,
+                             grpc_client=self.grpc_client,
+                             logger=self.logger.getChild(f"OtnsNode{node_id}"))
+        self.logger.debug(f"Adding new node {node_id} to OTNS")
+        otns_node.create_otns_node()
+        return otns_node
 
-    if node not in self.otns_node_map:
-      otns_node = self.add_device(node.device)
-      node.otns_manager = self
-      self.otns_node_map[node] = otns_node
+    def add_node(self, node: ThreadDevBoard):
+        """Add a node to OTNS visualization.
 
-      node_id = otns_node.node_id
-      self.node_summaries[node_id] = OtnsNodeSummary(node_id)
-    else:
-      otns_node = self.otns_node_map[node]
-      self.logger.debug(f"Adding existing node {otns_node.node_id} to OTNS")
-      node.otns_manager = self
-      self.otns_node_map[node].create_otns_node()
+        Args:
+            node (ThreadDevBoard): node to add, with dev board properties.
+        """
+        assert isinstance(node.device, HwModule), ("Adding non HwModule node to OTNS manager.")
 
-    self.max_node_count = max(self.max_node_count, len(self.otns_node_map))
-    self.update_layout()
+        if node not in self.otns_node_map:
+            otns_node = self.add_device(node.device)
+            node.otns_manager = self
+            self.otns_node_map[node] = otns_node
 
-  def remove_node(self, node: ThreadDevBoard):
-    """Remove a node from OTNS visualization.
+            node_id = otns_node.node_id
+            self.node_summaries[node_id] = OtnsNodeSummary(node_id)
+        else:
+            otns_node = self.otns_node_map[node]
+            self.logger.debug(f"Adding existing node {otns_node.node_id} to OTNS")
+            node.otns_manager = self
+            self.otns_node_map[node].create_otns_node()
 
-    Args:
-      node (ThreadDevBoard): node to remove, with dev board properties.
-    """
-    if node.otns_manager is self:
-      node.otns_manager = None
-
-      assert isinstance(node.device, HwModule), (
-          "Removing non HwModule node from OTNS manager.")
-
-      if node in self.otns_node_map:
-        otns_node = self.otns_node_map[node]
-        otns_node.close_socket()
-
-        node_id = otns_node.node_id
-        self.logger.debug(f"Removing node {node_id} from OTNS")
-        otns_node.delete_otns_node()
-
-        del self.otns_node_map[node]
-
+        self.max_node_count = max(self.max_node_count, len(self.otns_node_map))
         self.update_layout()
 
-  def remove_all_nodes(self):
-    """Remove all nodes from OTNS visualization.
-    """
-    nodes = list(self.otns_node_map.keys())
-    for node in nodes:
-      self.remove_node(node)
+    def remove_node(self, node: ThreadDevBoard):
+        """Remove a node from OTNS visualization.
 
-  def process_node_status(self, node: ThreadDevBoard,
-                          message: str, time=datetime.now()):
-    """Manually process a ThreadDevBoard status message.
+        Args:
+            node (ThreadDevBoard): node to remove, with dev board properties.
+        """
+        if node.otns_manager is self:
+            node.otns_manager = None
 
-    Args:
-      node (ThreadDevBoard): ThreadDevBoard node.
-      message (str): status message.
-      time (datetime, optional): time of the update. Defaults to
-        datetime.now().
-    """
-    if node in self.otns_node_map:
-      self.update_status(self.otns_node_map[node], message, time=time)
+            assert isinstance(node.device, HwModule), ("Removing non HwModule node from OTNS manager.")
 
-  def update_status(self, node: OtnsNode, message: str, time=datetime.now()):
-    """Manually update node status with a status message.
+            if node in self.otns_node_map:
+                otns_node = self.otns_node_map[node]
+                otns_node.close_socket()
 
-    Args:
-      node (OtnsNode): OTNS node.
-      message (str): status message.
-      time (datetime, optional): time of the update. Defaults to
-        datetime.now().
-    """
-    status_match = re.search(RegexType.STATUS.value, message)
-    if status_match:
-      message = status_match.group(2)
+                node_id = otns_node.node_id
+                self.logger.debug(f"Removing node {node_id} from OTNS")
+                otns_node.delete_otns_node()
 
-      extaddr_match = re.search(RegexType.EXTADDR_STATUS.value, message)
-      if extaddr_match:
-        extaddr = int(extaddr_match.group(1), 16)
-        node.update_extaddr(extaddr)
-        self.node_summaries[node.node_id].extaddr_changed(extaddr, time)
-        return
+                del self.otns_node_map[node]
 
-      role_match = re.search(RegexType.ROLE_STATUS.value, message)
-      if role_match:
-        role = RoleType(int(role_match.group(1)))
-        node.update_role(role)
-        self.node_summaries[node.node_id].role_changed(role, time)
-        self.update_layout()
+                self.update_layout()
 
-        if role == RoleType.DISABLED or role == RoleType.DETACHED:
-          for child in list(node.neighbors):
-            node.remove_router(child)
-            for neighbor in self.otns_node_map.values():
-              if neighbor.extaddr == child:
-                neighbor.remove_router(node.extaddr)
-                break
-          for child in list(node.children):
-            node.remove_child(child)
-        return
+    def remove_all_nodes(self):
+        """Remove all nodes from OTNS visualization.
+        """
+        nodes = list(self.otns_node_map.keys())
+        for node in nodes:
+            self.remove_node(node)
 
-      child_added_match = re.search(
-          RegexType.CHILD_ADDED_STATUS.value, message)
-      if child_added_match:
-        child = int(child_added_match.group(1), 16)
-        node.add_child(child)
-        self.node_summaries[node.node_id].child_changed(True, child, time)
-        return
+    def process_node_status(self, node: ThreadDevBoard, message: str, time=datetime.now()):
+        """Manually process a ThreadDevBoard status message.
 
-      child_removed_match = re.search(
-          RegexType.CHILD_REMOVED_STATUS.value, message)
-      if child_removed_match:
-        child = int(child_removed_match.group(1), 16)
-        node.remove_child(child)
-        self.node_summaries[node.node_id].child_changed(False, child, time)
-        return
+        Args:
+            node (ThreadDevBoard): ThreadDevBoard node.
+            message (str): status message.
+            time (datetime, optional): time of the update. Defaults to datetime.now().
+        """
+        if node in self.otns_node_map:
+            self.update_status(self.otns_node_map[node], message, time=time)
 
-      router_added_match = re.search(
-          RegexType.ROUTER_ADDED_STATUS.value, message)
-      if router_added_match:
-        router = int(router_added_match.group(1), 16)
-        node.add_router(router)
-        self.node_summaries[node.node_id].neighbor_changed(True, router, time)
-        return
+    def update_status(self, node: OtnsNode, message: str, time=datetime.now()):
+        """Manually update node status with a status message.
 
-      router_removed_match = re.search(
-          RegexType.ROUTER_REMOVED_STATUS.value, message)
-      if router_removed_match:
-        router = int(router_removed_match.group(1), 16)
-        node.remove_router(router)
-        self.node_summaries[node.node_id].neighbor_changed(False, router, time)
-        return
+        Args:
+            node (OtnsNode): OTNS node.
+            message (str): status message.
+            time (datetime, optional): time of the update. Defaults to datetime.now().
+        """
+        status_match = re.search(RegexType.STATUS.value, message)
+        if status_match:
+            message = status_match.group(2)
 
-      event = Event.status_event(message)
-      node.send_event(event.to_bytes())
-      return
+            extaddr_match = re.search(RegexType.EXTADDR_STATUS.value, message)
+            if extaddr_match:
+                extaddr = int(extaddr_match.group(1), 16)
+                node.update_extaddr(extaddr)
+                self.node_summaries[node.node_id].extaddr_changed(extaddr, time)
+                return
 
-    get_extaddr_info_match = re.search(
-        RegexType.GET_EXTADDR_RES.value, message)
-    if get_extaddr_info_match:
-      extaddr = get_extaddr_info_match.group(1)
-      node.update_extaddr(int(extaddr, 16))
-      return
+            role_match = re.search(RegexType.ROLE_STATUS.value, message)
+            if role_match:
+                role = RoleType(int(role_match.group(1)))
+                node.update_role(role)
+                self.node_summaries[node.node_id].role_changed(role, time)
+                self.update_layout()
 
-    ncp_version_match = re.search(RegexType.NCP_VERSION.value, message)
-    if ncp_version_match:
-      ncp_version = ncp_version_match.group(1)
-      self.grpc_client.set_netinfo(version=ncp_version)
-      return
+                if role in (RoleType.DISABLED, RoleType.DETACHED):
+                    for child in list(node.neighbors):
+                        node.remove_router(child)
+                        for neighbor in self.otns_node_map.values():
+                            if neighbor.extaddr == child:
+                                neighbor.remove_router(node.extaddr)
+                                break
+                    for child in list(node.children):
+                        node.remove_child(child)
+                return
 
-  def set_ncp_version(self, version: str):
-    """Set NCP version for display on OTNS.
+            child_added_match = re.search(RegexType.CHILD_ADDED_STATUS.value, message)
+            if child_added_match:
+                child = int(child_added_match.group(1), 16)
+                node.add_child(child)
+                self.node_summaries[node.node_id].child_changed(True, child, time)
+                return
 
-    Args:
-      version (str): version string.
-    """
-    self.grpc_client.set_netinfo(version=version)
+            child_removed_match = re.search(RegexType.CHILD_REMOVED_STATUS.value, message)
+            if child_removed_match:
+                child = int(child_removed_match.group(1), 16)
+                node.remove_child(child)
+                self.node_summaries[node.node_id].child_changed(False, child, time)
+                return
 
-  def update_extaddr(self, node: ThreadDevBoard,
-                     extaddr: int, time=datetime.now()):
-    """Report a node's extended address to OTNS manager.
+            router_added_match = re.search(RegexType.ROUTER_ADDED_STATUS.value, message)
+            if router_added_match:
+                router = int(router_added_match.group(1), 16)
+                node.add_router(router)
+                self.node_summaries[node.node_id].neighbor_changed(True, router, time)
+                return
 
-    Args:
-      node (ThreadDevBoard): node to update.
-      extaddr (int): new extaddr to report.
-      time (datetime.datetime, optional): time of the update. Defaults to
-        datetime.now().
-    """
-    if node in self.otns_node_map:
-      self.otns_node_map[node].update_extaddr(extaddr)
-      node_id = self.otns_node_map[node].node_id
+            router_removed_match = re.search(RegexType.ROUTER_REMOVED_STATUS.value, message)
+            if router_removed_match:
+                router = int(router_removed_match.group(1), 16)
+                node.remove_router(router)
+                self.node_summaries[node.node_id].neighbor_changed(False, router, time)
+                return
 
-      if node_id in self.node_summaries:
-        self.node_summaries[node_id].extaddr_changed(extaddr, time=time)
+            event = Event.status_event(message)
+            node.send_event(event.to_bytes())
+            return
 
-      self.update_layout()
+        get_extaddr_info_match = re.search(RegexType.GET_EXTADDR_RES.value, message)
+        if get_extaddr_info_match:
+            extaddr = get_extaddr_info_match.group(1)
+            node.update_extaddr(int(extaddr, 16))
+            return
 
-  def subscribe_to_node(self, node: ThreadDevBoard):
-    """Create a wpantund OTNS monitor and subscribe it to the node.
+        ncp_version_match = re.search(RegexType.NCP_VERSION.value, message)
+        if ncp_version_match:
+            ncp_version = ncp_version_match.group(1)
+            self.grpc_client.set_netinfo(version=ncp_version)
+            return
 
-    Args:
-      node (ThreadDevBoard): node to subscribe to.
-    """
-    if node in self.otns_node_map:
-      self.logger.debug(
-          f"Subscribing to node {self.otns_node_map[node].node_id}")
-      wpantund_otns_monitor = WpantundOtnsMonitor(
-          publisher=node.wpantund_process)
-      wpantund_otns_monitor.node = self.otns_node_map[node]
-      wpantund_otns_monitor.otns_manager = self
-      self.otns_monitor_map[node] = wpantund_otns_monitor
+    def set_ncp_version(self, version: str):
+        """Set NCP version for display on OTNS.
 
-  def unsubscribe_from_node(self, node: ThreadDevBoard):
-    """Remove the wpantund OTNS subscriber of the node.
+        Args:
+            version (str): version string.
+        """
+        self.grpc_client.set_netinfo(version=version)
 
-    Args:
-      node (ThreadDevBoard): node to unsubscribe from.
-    """
-    if node in self.otns_node_map and node in self.otns_monitor_map:
-      self.logger.debug(
-          f"Unsubscribing from node {self.otns_node_map[node].node_id}")
-      self.otns_monitor_map[node].unsubscribe()
-      self.otns_monitor_map[node].otns_manager = None
-      del self.otns_monitor_map[node]
+    def update_extaddr(self, node: ThreadDevBoard, extaddr: int, time=datetime.now()):
+        """Report a node's extended address to OTNS manager.
 
-  def unsubscribe_from_all_nodes(self):
-    """Unsubscribe the manager from all nodes.
-    """
-    self.logger.debug("Unsubscribing from all nodes")
-    for subscriber in self.otns_monitor_map.values():
-      subscriber.unsubscribe()
-    self.otns_monitor_map.clear()
+        Args:
+            node (ThreadDevBoard): node to update.
+            extaddr (int): new extaddr to report.
+            time (datetime.datetime, optional): time of the update. Defaults to datetime.now().
+        """
+        if node in self.otns_node_map:
+            self.otns_node_map[node].update_extaddr(extaddr)
+            node_id = self.otns_node_map[node].node_id
 
-  def update_layout(self, use_two_layer=False):
-    """Update layout of nodes in auto layout mode.
+            if node_id in self.node_summaries:
+                self.node_summaries[node_id].extaddr_changed(extaddr, time=time)
 
-    Args:
-      use_two_layer (bool, optional): if layout uses separate circles for
-        routers and EDs. Defaults to False.
-    """
-    no_nodes = not self.otns_node_map or self.max_node_count == 0
-    if not self.auto_layout or no_nodes:
-      return
+            self.update_layout()
 
-    self.logger.debug("Updating nodes layout")
-    first_node = next(iter(self.otns_node_map))
-    center_x, center_y = first_node.device.get_otns_vis_layout_center()
-    radius = first_node.device.get_otns_vis_layout_radius()
+    def subscribe_to_node(self, node: ThreadDevBoard):
+        """Create a wpantund OTNS monitor and subscribe it to the node.
 
-    routers = set()
-    others = set()
+        Args:
+            node (ThreadDevBoard): node to subscribe to.
+        """
+        if node in self.otns_node_map:
+            self.logger.debug(f"Subscribing to node {self.otns_node_map[node].node_id}")
+            wpantund_otns_monitor = WpantundOtnsMonitor(publisher=node.wpantund_process)
+            wpantund_otns_monitor.node = self.otns_node_map[node]
+            wpantund_otns_monitor.otns_manager = self
+            self.otns_monitor_map[node] = wpantund_otns_monitor
 
-    for node in self.otns_node_map.values():
-      if node.role == RoleType.ROUTER or node.role == RoleType.LEADER:
-        routers.add(node)
-      else:
-        others.add(node)
+    def unsubscribe_from_node(self, node: ThreadDevBoard):
+        """Remove the wpantund OTNS subscriber of the node.
 
-    if not routers and not others:
-      return
+        Args:
+            node (ThreadDevBoard): node to unsubscribe from.
+        """
+        if node in self.otns_node_map and node in self.otns_monitor_map:
+            self.logger.debug(f"Unsubscribing from node {self.otns_node_map[node].node_id}")
+            self.otns_monitor_map[node].unsubscribe()
+            self.otns_monitor_map[node].otns_manager = None
+            del self.otns_monitor_map[node]
 
-    if use_two_layer:
-      router_list = list(routers)
-      other_list = list(others)
-      router_list.sort(key=lambda x: x.node_id)
-      other_list.sort(key=lambda x: x.node_id)
-      groups = [other_list, router_list]
-    else:
-      node_list = list(routers) + list(others)
-      node_list.sort(key=lambda x: x.node_id)
-      groups = [node_list]
+    def unsubscribe_from_all_nodes(self):
+        """Unsubscribe the manager from all nodes.
+        """
+        self.logger.debug("Unsubscribing from all nodes")
+        for subscriber in self.otns_monitor_map.values():
+            subscriber.unsubscribe()
+        self.otns_monitor_map.clear()
 
-    angle_step = math.radians(360 / self.max_node_count)
-    for i, group in enumerate(groups):
-      group_radius = radius / (i + 1)
-      for node in group:
-        angle = angle_step * node.node_id
-        self.layout_node(node, center_x, center_y, group_radius, angle)
+    def update_layout(self, use_two_layer=False):
+        """Update layout of nodes in auto layout mode.
 
-  def layout_node(self, node: OtnsNode, center_x: int, center_y: int,
-                  radius: float, angle: float):
-    """Update a single node's visualization position.
+        Args:
+            use_two_layer (bool, optional): if layout uses separate circles for routers and EDs. Defaults to False.
+        """
+        no_nodes = not self.otns_node_map or self.max_node_count == 0
+        if not self.auto_layout or no_nodes:
+            return
 
-    Args:
-        node (OtnsNode): node to update visualization.
-        center_x (int): layout circle center x coordinate.
-        center_y (int): layout circle center y coordinate.
-        radius (float): layout circle radius.
-        angle (float): angle of node on the circle.
-    """
-    x = center_x + radius * math.cos(angle)
-    y = center_y + radius * math.sin(angle)
-    node.update_vis_position(int(x), int(y))
+        self.logger.debug("Updating nodes layout")
+        first_node = next(iter(self.otns_node_map))
+        center_x, center_y = first_node.device.get_otns_vis_layout_center()
+        radius = first_node.device.get_otns_vis_layout_radius()
+
+        routers = set()
+        others = set()
+
+        for node in self.otns_node_map.values():
+            if node.role == RoleType.ROUTER or node.role == RoleType.LEADER:
+                routers.add(node)
+            else:
+                others.add(node)
+
+        if not routers and not others:
+            return
+
+        if use_two_layer:
+            router_list = list(routers)
+            other_list = list(others)
+            router_list.sort(key=lambda x: x.node_id)
+            other_list.sort(key=lambda x: x.node_id)
+            groups = [other_list, router_list]
+        else:
+            node_list = list(routers) + list(others)
+            node_list.sort(key=lambda x: x.node_id)
+            groups = [node_list]
+
+        angle_step = math.radians(360 / self.max_node_count)
+        for i, group in enumerate(groups):
+            group_radius = radius / (i + 1)
+            for node in group:
+                angle = angle_step * node.node_id
+                self.layout_node(node, center_x, center_y, group_radius, angle)
+
+    def layout_node(self, node: OtnsNode, center_x: int, center_y: int, radius: float, angle: float):
+        """Update a single node's visualization position.
+
+        Args:
+            node (OtnsNode): node to update visualization.
+            center_x (int): layout circle center x coordinate.
+            center_y (int): layout circle center y coordinate.
+            radius (float): layout circle radius.
+            angle (float): angle of node on the circle.
+        """
+        x = center_x + radius * math.cos(angle)
+        y = center_y + radius * math.sin(angle)
+        node.update_vis_position(int(x), int(y))

--- a/silk/tools/usbdevice.py
+++ b/silk/tools/usbdevice.py
@@ -12,28 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import chr
+import collections
 import re
 import sys
 import usbinfo
-import collections
-
 """Config file key words"""
-CONFIG_SERIAL_NUMBER = 'iSerialNumber'
-CONFIG_INTERFACE_NUMBER = 'bInterfaceNumber'
-CONFIG_DEVNAME = 'devname'
-CONFIG_MANUFACTURER = 'iManufacturer'
-CONFIG_PRODUCT_NAME = 'iProduct'
-CONFIG_PID = 'idProduct'
-CONFIG_VID = 'idVendor'
+CONFIG_SERIAL_NUMBER = "iSerialNumber"
+CONFIG_INTERFACE_NUMBER = "bInterfaceNumber"
+CONFIG_DEVNAME = "devname"
+CONFIG_MANUFACTURER = "iManufacturer"
+CONFIG_PRODUCT_NAME = "iProduct"
+CONFIG_PID = "idProduct"
+CONFIG_VID = "idVendor"
 
-
-"""Regular expressions for parsing out serial number from the device name"""
+# Regular expressions for parsing out serial number from the device name
 
 # eg. /dev/tty.usbserial-14232A
-DEVICE_NAME_SERIAL_REGEX = re.compile("/dev/tty\.usbserial\-(\w*)[A-Z]")
+DEVICE_NAME_SERIAL_REGEX = re.compile(r"/dev/tty\.usbserial\-(\w*)[A-Z]")
 
-DEVICE_KNOWN_LIST = ('nRF52840_OpenThread_Device',)
+DEVICE_KNOWN_LIST = ("nRF52840_OpenThread_Device",)
 
 
 def devname_get_serial(devname):
@@ -57,9 +54,8 @@ def device_get_serial_from_devname(device):
 
 
 def device_get_serial(device):
-    """
-    Gets the serial number for a particular devcie
-    """
+    """Gets the serial number for a particular devcie.
+  """
     serial = device[CONFIG_SERIAL_NUMBER]
     if len(serial) == 0:
         serial = device_get_serial_from_devname(device)
@@ -68,17 +64,15 @@ def device_get_serial(device):
 
 
 def device_get_interface_number(device):
-    """
-    Gets the interface number for a specified device
-    """
+    """Gets the interface number for a specified device.
+  """
 
     return int(device[CONFIG_INTERFACE_NUMBER])
 
 
 def device_get_devname(device):
-    """
-    Gets the devname of the specified devcie
-    """
+    """Gets the devname of the specified device.
+  """
 
     retval = None
 
@@ -90,9 +84,9 @@ def device_get_devname(device):
     # The device should mount as /dev/tty.usbserial-<serial#>
     # followed by a letter.  The letter starts at A and
     # incrememts on the interface_number.
-    elif sys.platform == 'darwin':
-        retval = '/dev/tty.usbserial-%s' % device_get_serial(device)
-        retval += chr(ord('A') + int(device_get_interface_number(device)))
+    elif sys.platform == "darwin":
+        retval = "/dev/tty.usbserial-%s" % device_get_serial(device)
+        retval += chr(ord("A") + int(device_get_interface_number(device)))
 
     return retval
 
@@ -127,14 +121,14 @@ def device_find_from_serial(device_type, serial, interface_number):
 def get_all_connected_serial_devices():
 
     device_dict = collections.defaultdict(set)
-    device_dict['Wpantund'] = {}
+    device_dict["Wpantund"] = {}
 
     devices = usbinfo.usbinfo()
 
     for device in devices:
-        device_name = device['iProduct']
+        device_name = device["iProduct"]
 
         if device_name in DEVICE_KNOWN_LIST:
-            device_dict[device_name].add(device['iSerialNumber'])
+            device_dict[device_name].add(device["iSerialNumber"])
 
     return device_dict

--- a/silk/tools/watchable.py
+++ b/silk/tools/watchable.py
@@ -11,24 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+"""Watchable, an implementation of an object whose state can be watched.
 """
-Watchable, an implementation of an object whose state can be watched
-"""
-from __future__ import absolute_import
-
-from builtins import str
-from builtins import object
-import threading
 
 from datetime import datetime
+import threading
 
 from . import deadline as silk_deadline
 
 
 def is_watchable(object):
-    return (isinstance(object, WatchableWithHistory) or
-        isinstance(object, Watchable))
+    return (isinstance(object, WatchableWithHistory) or isinstance(object, Watchable))
 
 
 # An object whose state can be watched
@@ -37,7 +30,7 @@ class Watchable(object):
     # @param value The initial value for this watchable
     # @param name The name for this watchable, for logging only
     # @Param logger A logger to invoke any logging operations
-    def __init__(self, value, name = None, logger = None):
+    def __init__(self, value, name=None, logger=None):
         self.value = value
         self.__lock = threading.Lock()
         self.__watchers = []
@@ -75,12 +68,12 @@ class Watchable(object):
 
     def __str__(self):
         return str(self.value)
-    
+
     # Get the name
     # @returns The name
     @property
     def name(self):
-        return self.__name;
+        return self.__name
 
     # Set the contained property
     # @param new_value The value to set
@@ -98,7 +91,7 @@ class Watchable(object):
     # @param lambda_func A function or callable that returns not None when the desired watch condition is Met
     # @param timeout Timeout in seconds. Specify None for no timeout
     # @return The result of the watch function. A None result implies a timeout
-    def watch(self, lambda_func, timeout = None, must_update = False):
+    def watch(self, lambda_func, timeout=None, must_update=False):
         retval = None
 
         deadline = silk_deadline.Deadline(timeout)
@@ -139,8 +132,8 @@ class Watchable(object):
     # cases where an asynchronous operation (i.e a command) is pending and we want to
     # wait until things are updated
     # @param timeout Timeout in seconds. Specify None for no timeout
-    def watch_for_update(self, timeout = None):
-        return self.watch(lambda v: True, must_update = True)
+    def watch_for_update(self, timeout=None):
+        return self.watch(lambda v: True, must_update=True)
 
 
 # A watchable state that also tracks history of the object changing
@@ -149,7 +142,7 @@ class WatchableWithHistory(object):
     # @param initial_value The initial value of this watchable. Does not count towards history
     # @param name The name for this watchable, for logging only
     # @Param logger A logger to invoke any logging operations
-    def __init__(self, initial_value = None, name = None, logger = None):
+    def __init__(self, initial_value=None, name=None, logger=None):
         self.__history = []
         self.__initial_value = initial_value
         self.__value = Watchable(None, name, logger)
@@ -165,7 +158,7 @@ class WatchableWithHistory(object):
         return str(self.__value)
 
     def __update_value(self):
-        if len(self.__history):
+        if self.__history:
             [time, value] = self.__history[-1]
             self.__value.set(value)
 
@@ -173,7 +166,7 @@ class WatchableWithHistory(object):
     def get(self):
         retval = None
 
-        if len(self.__history):
+        if self.__history:
             retval = self.__value.get()
         else:
             retval = self.__initial_value
@@ -207,15 +200,15 @@ class WatchableWithHistory(object):
     def set(self, value):
         return self.append([datetime.now(), value])
 
-    # Perform a watch. See the description of 'watch' above for Watchable
+    # Perform a watch. See the description of "watch" above for Watchable
     # @param lambda_func A callable
     # @param timeout  Timeout in seconds
     # @return the result of the lambda function
-    def watch(self, lambda_func, timeout = None):
+    def watch(self, lambda_func, timeout=None):
         return self.__value.watch(lambda_func, timeout)
 
     # Perform a watch, for any change to this object. Useful
     # For waiting for a side effect to take place on a watchable
     # object after issuing a command
-    def watch_for_update(self, timeout = None):
+    def watch_for_update(self, timeout=None):
         return self.__value.watch_for_update(timeout)

--- a/silk/tools/wpan_table_parser.py
+++ b/silk/tools/wpan_table_parser.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
 # Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,12 +12,10 @@ from __future__ import absolute_import
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 
-from builtins import object
 from . import wpan_util
 from silk.config import wpan_constants as wpan
-
-import re
 
 
 def is_associated(sed):
@@ -32,7 +28,8 @@ def check_child_is_detached(sed):
 
 
 class ChildAddressEntry(object):
-    """ This object encapsulates a child Address entry"""
+    """This object encapsulates a child Address entry.
+    """
 
     def __init__(self, text):
 
@@ -40,18 +37,18 @@ class ChildAddressEntry(object):
         #
         # `\t"9A456FEEC738F641, RLOC16:1402, IPv6Addrs:[fd74:5d77:b280:0:c7a2:c449:b097:147f]"`
         #
-        # We get rid of the first two chars `\t"' and last char '"', split the rest using whitespace as separator.
-        # Then remove any ',' at end of items in the list.
-        items = [item for item in text[2:-1].split(', ', 2)]
+        # We get rid of the first two chars `\t"` and last char `"``, split the rest using whitespace as separator.
+        # Then remove any `,` at end of items in the list.
+        items = text[2:-1].split(", ", 2)
 
         # First item in the extended address
         self._ext_address = items[0]
 
-        # Convert the rest into a dictionary by splitting using ':' as separator
-        dict = {item.split(':', 1)[0]: item.split(':', 1)[1] for item in items[1:]}
+        # Convert the rest into a dictionary by splitting using `:` as separator
+        items_dict = {item.split(":", 1)[0]: item.split(":", 1)[1] for item in items[1:]}
 
-        self._rloc16        = dict['RLOC16']
-        self._ipv6_address       = dict['IPv6Addrs'] if 'IPv6Addrs' in dict else ''
+        self._rloc16 = items_dict["RLOC16"]
+        self._ipv6_address = items_dict["IPv6Addrs"] if "IPv6Addrs" in items_dict else ""
 
     @property
     def ext_address(self):
@@ -66,11 +63,12 @@ class ChildAddressEntry(object):
         return self._ipv6_address
 
     def __repr__(self):
-        return 'ChildEntry({})'.format(self.__dict__)
+        return "ChildEntry({})".format(self.__dict__)
 
 
 class ChildEntry(object):
-    """ This object encapsulates a child entry"""
+    """This object encapsulates a child entry.
+    """
 
     def __init__(self, text):
 
@@ -80,22 +78,22 @@ class ChildEntry(object):
         # `RxOnIdle:no, FTD:no, SecDataReq:yes, FullNetData:yes"`
         #
 
-        # We get rid of the first two chars `\t"' and last char '"', split the rest using whitespace as separator.
-        # Then remove any ',' at end of items in the list.
-        items = [item[:-1] if item[-1] == ',' else item for item in text[2:-1].split()]
+        # We get rid of the first two chars `\t"` and last char `"`, split the rest using whitespace as separator.
+        # Then remove any `,` at end of items in the list.
+        items = [item[:-1] if item[-1] == "," else item for item in text[2:-1].split()]
 
         # First item in the extended address
         self._ext_address = items[0]
 
-        # Convert the rest into a dictionary by splitting using ':' as separator
-        dict = {item.split(':')[0]: item.split(':')[1] for item in items[1:]}
+        # Convert the rest into a dictionary by splitting using `:` as separator
+        items_dict = {item.split(":")[0]: item.split(":")[1] for item in items[1:]}
 
-        self._rloc16        = dict['RLOC16']
-        self._timeout       = dict['Timeout']
-        self._rx_on_idle    = (dict['RxOnIdle'] == 'yes')
-        self._ftd           = (dict['FTD'] == 'yes')
-        self._sec_data_req  = (dict['SecDataReq'] == 'yes')
-        self._full_net_data = (dict['FullNetData'] == 'yes')
+        self._rloc16 = items_dict["RLOC16"]
+        self._timeout = items_dict["Timeout"]
+        self._rx_on_idle = (items_dict["RxOnIdle"] == "yes")
+        self._ftd = (items_dict["FTD"] == "yes")
+        self._sec_data_req = (items_dict["SecDataReq"] == "yes")
+        self._full_net_data = (items_dict["FullNetData"] == "yes")
 
     @property
     def ext_address(self):
@@ -122,50 +120,53 @@ class ChildEntry(object):
         return self._full_net_data
 
     def __repr__(self):
-        return 'ChildEntry({})'.format(self.__dict__)
+        return "ChildEntry({})".format(self.__dict__)
 
 
 def parse_child_table_result(child_table_list):
-    """ Parses child table list string and returns an array of `ChildEntry` objects"""
-    items = child_table_list.split('\n')[1:-1]
-    if items and ']' in items[-1]:
+    """Parses child table list string and returns an array of `ChildEntry` objects.
+    """
+    items = child_table_list.split("\n")[1:-1]
+    if items and "]" in items[-1]:
         items.pop()
     return [ChildEntry(item) for item in items]
 
 
 def parse_child_table_address_result(child_table_list):
-    """ Parses child table list string and returns an array of `ChildEntry` objects"""
-    items = child_table_list.split('\n')[1:-1]
-    if items and ']' == items[-1]:
+    """Parses child table list string and returns an array of `ChildEntry` objects.
+    """
+    items = child_table_list.split("\n")[1:-1]
+    if items and "]" == items[-1]:
         items.pop()
     return [ChildAddressEntry(item) for item in items]
 
 
 class NeighborEntry(object):
-    """ This object encapsulates a neighbor entry"""
+    """This object encapsulates a neighbor entry.
+    """
 
     def __init__(self, text):
 
         # Example of expected text:
         #
-        # `\t"5AC95ED4646D6565, RLOC16:9403, LQIn:3, AveRssi:-20, LastRssi:-20, Age:0, LinkFC:8, MleFC:0, IsChild:yes, '
-        # 'RxOnIdle:no, FTD:no, SecDataReq:yes, FullNetData:yes"'
+        # `\t"5AC95ED4646D6565, RLOC16:9403, LQIn:3, AveRssi:-20, LastRssi:-20, Age:0, LinkFC:8, MleFC:0, `
+        # `IsChild:yes, RxOnIdle:no, FTD:no, SecDataReq:yes, FullNetData:yes"`
         #
 
-        # We get rid of the first two chars `\t"' and last char '"', split the rest using whitespace as separator.
-        # Then remove any ',' at end of items in the list.
-        items = [item[:-1] if item[-1] == ',' else item for item in text[2:-1].split()]
+        # We get rid of the first two chars `\t"` and last char `"`, split the rest using whitespace as separator.
+        # Then remove any `,` at end of items in the list.
+        items = [item[:-1] if item[-1] == "," else item for item in text[2:-1].split()]
 
         # First item in the extended address
         self._ext_address = items[0]
 
-        # Convert the rest into a dictionary by splitting the text using ':' as separator
-        dict = {item.split(':')[0]: item.split(':')[1] for item in items[1:]}
+        # Convert the rest into a dictionary by splitting the text using `:` as separator
+        items_dict = {item.split(":")[0]: item.split(":")[1] for item in items[1:]}
 
-        self._rloc16     = dict['RLOC16']
-        self._is_child   = (dict['IsChild'] == 'yes')
-        self._rx_on_idle = (dict['RxOnIdle'] == 'yes')
-        self._ftd        = (dict['FTD'] == 'yes')
+        self._rloc16 = items_dict["RLOC16"]
+        self._is_child = (items_dict["IsChild"] == "yes")
+        self._rx_on_idle = (items_dict["RxOnIdle"] == "yes")
+        self._ftd = (items_dict["FTD"] == "yes")
 
     @property
     def ext_address(self):
@@ -185,19 +186,21 @@ class NeighborEntry(object):
         return self._is_child
 
     def __repr__(self):
-        return 'NeighborEntry({})'.format(self.__dict__)
+        return "NeighborEntry({})".format(self.__dict__)
 
 
 def parse_neighbor_table_result(neighbor_table_list):
-    """ Parses neighbor table list string and returns an array of `NeighborEntry` objects"""
-    items = neighbor_table_list.split('\n')[1:-1]
-    if items and ']' in items[-1]:
+    """Parses neighbor table list string and returns an array of `NeighborEntry` objects.
+    """
+    items = neighbor_table_list.split("\n")[1:-1]
+    if items and "]" in items[-1]:
         items.pop()
     return [NeighborEntry(item) for item in items]
 
 
 class RouterTableEntry(object):
-    """ This object encapsulates a router table entry"""
+    """This object encapsulates a router table entry.
+    """
 
     def __init__(self, text):
 
@@ -206,22 +209,22 @@ class RouterTableEntry(object):
         # `\t"8A970B3251810826, RLOC16:4000, RouterId:16, NextHop:43, PathCost:1, LQIn:3, LQOut:3, Age:3, LinkEst:yes"`
         #
 
-        # We get rid of the first two chars `\t"' and last char '"', split the rest using whitespace as separator.
-        # Then remove any ',' at end of items in the list.
-        items = [item[:-1] if item[-1] ==',' else item for item in text[2:-1].split()]
+        # We get rid of the first two chars `\t"` and last char `"`, split the rest using whitespace as separator.
+        # Then remove any `,` at end of items in the list.
+        items = [item[:-1] if item[-1] == "," else item for item in text[2:-1].split()]
 
         # First item in the extended address
         self._ext_address = items[0]
 
-        # Convert the rest into a dictionary by splitting the text using ':' as separator
-        dict = {item.split(':')[0] : item.split(':')[1] for item in items[1:]}
+        # Convert the rest into a dictionary by splitting the text using `:` as separator
+        items_dict = {item.split(":")[0]: item.split(":")[1] for item in items[1:]}
 
-        self._rloc16    = int(dict['RLOC16'], 16)
-        self._router_id = int(dict['RouterId'], 0)
-        self._next_hop  = int(dict['NextHop'], 0)
-        self._path_cost = int(dict['PathCost'], 0)
-        self._age       = int(dict['Age'], 0)
-        self._le        = (dict['LinkEst'] == 'yes')
+        self._rloc16 = int(items_dict["RLOC16"], 16)
+        self._router_id = int(items_dict["RouterId"], 0)
+        self._next_hop = int(items_dict["NextHop"], 0)
+        self._path_cost = int(items_dict["PathCost"], 0)
+        self._age = int(items_dict["Age"], 0)
+        self._le = items_dict["LinkEst"] == "yes"
 
     @property
     def ext_address(self):
@@ -247,36 +250,38 @@ class RouterTableEntry(object):
         return self._le
 
     def __repr__(self):
-        return 'RouterTableEntry({})'.format(self.__dict__)
+        return "RouterTableEntry({})".format(self.__dict__)
 
 
 def parse_router_table_result(router_table_list):
-    """ Parses router table list string and returns an array of `RouterTableEntry` objects"""
-    return [RouterTableEntry(item) for item in router_table_list.split('\n')[1:-1]]
+    """Parses router table list string and returns an array of `RouterTableEntry` objects.
+    """
+    return [RouterTableEntry(item) for item in router_table_list.split("\n")[1:-1]]
 
 
 class AddressCacheEntry(object):
-    """ This object encapsulates an address cache entry"""
+    """This object encapsulates an address cache entry.
+    """
 
     def __init__(self, text):
 
         # Example of expected text:
         #
-        # '\t"fd00:1234::d427:a1d9:6204:dbae -> 0x9c00, age:0"'
+        # `\t"fd00:1234::d427:a1d9:6204:dbae -> 0x9c00, age:0"`
         #
 
-        # We get rid of the first two chars `\t"' and last char '"', split the rest using whitespace as separator.
-        # Then remove any ',' at end of items in the list.
-        items = [item[:-1] if item[-1] ==',' else item for item in text[2:-1].split()]
+        # We get rid of the first two chars `\t"` and last char `"`, split the rest using whitespace as separator.
+        # Then remove any `,` at end of items in the list.
+        items = [item[:-1] if item[-1] == "," else item for item in text[2:-1].split()]
 
         # First item in the extended address
         self._address = items[0]
-        self._rloc16    = int(items[2], 16)
+        self._rloc16 = int(items[2], 16)
 
-        # Convert the rest into a dictionary by splitting the text using ':' as separator
-        dict = {item.split(':')[0] : item.split(':')[1] for item in items[3:]}
+        # Convert the rest into a dictionary by splitting the text using `:` as separator
+        items_dict = {item.split(":")[0]: item.split(":")[1] for item in items[3:]}
 
-        self._age       = int(dict['age'], 0)
+        self._age = int(items_dict["age"], 0)
 
     @property
     def address(self):
@@ -291,52 +296,55 @@ class AddressCacheEntry(object):
         return self._age
 
     def __repr__(self):
-        return 'AddressCacheEntry({})'.format(self.__dict__)
+        return "AddressCacheEntry({})".format(self.__dict__)
 
 
 def parse_address_cache_table_result(addr_cache_table_list):
-    """ Parses address cache table list string and returns an array of `AddressCacheEntry` objects"""
-    return [AddressCacheEntry(item) for item in addr_cache_table_list.split('\n')[1:-1]]
+    """Parses address cache table list string and returns an array of `AddressCacheEntry` objects.
+    """
+    return [AddressCacheEntry(item) for item in addr_cache_table_list.split("\n")[1:-1]]
+
 
 # wpan scan parse
 
 
 class ScanResult(object):
-    """ This object encapsulates a scan result (active/discover/energy scan)"""
+    """This object encapsulates a scan result (active/discover/energy scan)/
+    """
 
-    TYPE_ACTIVE_SCAN     = 'active-scan'
-    TYPE_DISCOVERY_SCAN  = 'discover-scan'
-    TYPE_ENERGY_SCAN     = 'energy-scan'
+    TYPE_ACTIVE_SCAN = "active-scan"
+    TYPE_DISCOVERY_SCAN = "discover-scan"
+    TYPE_ENERGY_SCAN = "energy-scan"
 
     def __init__(self, result_text):
 
-        items = [item.strip() for item in result_text.split('|')]
+        items = [item.strip() for item in result_text.split("|")]
 
         if len(items) == 8:
-            self._type         = ScanResult.TYPE_ACTIVE_SCAN
-            self._index        = items[0]
-            self._joinable     = (items[1] == 'YES')
+            self._type = ScanResult.TYPE_ACTIVE_SCAN
+            self._index = items[0]
+            self._joinable = items[1] == "YES"
             self._network_name = items[2][1:-1]
-            self._panid        = items[3]
-            self._channel      = items[4]
-            self._xpanid       = items[5]
-            self._ext_address  = items[6]
-            self._rssi         = items[7]
+            self._panid = items[3]
+            self._channel = items[4]
+            self._xpanid = items[5]
+            self._ext_address = items[6]
+            self._rssi = items[7]
         elif len(items) == 7:
-            self._type         = ScanResult.TYPE_DISCOVERY_SCAN
-            self._index        = items[0]
+            self._type = ScanResult.TYPE_DISCOVERY_SCAN
+            self._index = items[0]
             self._network_name = items[1][1:-1]
-            self._panid        = items[2]
-            self._channel      = items[3]
-            self._xpanid       = items[4]
-            self._ext_address  = items[5]
-            self._rssi         = items[6]
+            self._panid = items[2]
+            self._channel = items[3]
+            self._xpanid = items[4]
+            self._ext_address = items[5]
+            self._rssi = items[6]
         elif len(items) == 2:
-            self._type         = ScanResult.TYPE_ENERGY_SCAN
-            self._channel      = items[0]
-            self._rssi         = items[1]
+            self._type = ScanResult.TYPE_ENERGY_SCAN
+            self._channel = items[0]
+            self._rssi = items[1]
         else:
-            raise ValueError('"{}" does not seem to be a valid scan result string'.result_text)
+            raise ValueError(f"'{result_text}' does not seem to be a valid scan result string")
 
     @property
     def type(self):
@@ -371,7 +379,7 @@ class ScanResult(object):
         return self._rssi
 
     def __repr__(self):
-        return 'ScanResult({})'.format(self.__dict__)
+        return "ScanResult({})".format(self.__dict__)
 
 
 def parse_scan_result(scan_result):
@@ -379,21 +387,23 @@ def parse_scan_result(scan_result):
     Parses scan result string and returns an array of `ScanResult` objects
     scan result is a string like:
       | Joinable | NetworkName        | PAN ID | Ch | XPanID           | HWAddr           | RSSI
----+----------+--------------------+--------+----+------------------+------------------+------
- 1 |       NO | "SILK-EDD6"      | 0xED69 | 11 | AFA702E6A80E008E | D266199DD2D5FD04 |  -31
- 2 |       NO | "Silk-PAN-8ACE"    | 0x0CE2 | 11 | 647A2248881784BD | 6A54247406E3CA3C |  -56
- 3 |       NO | "Silk-PAN-F926"    | 0x3DDA | 11 | E35BFBBBB014A4FF | EAD5AFC58F50D056 |  -49
-    Exclude the last item '"' after split('\n')
+    --+----------+--------------------+--------+----+------------------+------------------+------
+    1 |       NO | "SILK-EDD6"        | 0xED69 | 11 | AFA702E6A80E008E | D266199DD2D5FD04 |  -31
+    2 |       NO | "Silk-PAN-8ACE"    | 0x0CE2 | 11 | 647A2248881784BD | 6A54247406E3CA3C |  -56
+    3 |       NO | "Silk-PAN-F926"    | 0x3DDA | 11 | E35BFBBBB014A4FF | EAD5AFC58F50D056 |  -49
+    Exclude the last item `"` after split(`\n`)
     """
     print(scan_result)
-    return [ScanResult(item) for item in scan_result.strip().split('\n')[2:]]  # skip first two lines which are table headers
+    return [ScanResult(item) for item in scan_result.strip().split("\n")[2:]
+           ]  # skip first two lines which are table headers
 
 
 def is_in_scan_result(node, scan_results):
-    """Checks if node is in the scan results list
-       `scan_result`s must be list of list of `ScanResult` object (see `parse_scan_result`).
+    """Checks if node is in the scan results list.
+
+    `scan_result`s must be list of list of `ScanResult` object (see `parse_scan_result`).
     """
-    joinable = (node.get(wpan.WPAN_NETWORK_ALLOW_JOIN).strip() == 'true')
+    joinable = (node.get(wpan.WPAN_NETWORK_ALLOW_JOIN).strip() == "true")
     panid = node.get(wpan.WPAN_PANID)
     xpanid = node.get(wpan.WPAN_XPANID)[2:]
     name = node.get(wpan.WPAN_NAME)[1:-1]
@@ -405,18 +415,20 @@ def is_in_scan_result(node, scan_results):
         for item in scan_result:
 
             if item.network_name == name:
-                print([item.panid.strip() == panid.strip(),
-                       item.xpanid.strip() == xpanid.strip(),
-                       int(item.channel, 16) == int(channel, 16),
-                       item.ext_address == ext_address,
-                       (item.type == ScanResult.TYPE_DISCOVERY_SCAN) or (item.joinable == joinable)])
-
-            if all([item.network_name == name,
+                print([
                     item.panid.strip() == panid.strip(),
                     item.xpanid.strip() == xpanid.strip(),
-                    int(item.channel, 16) == int(channel, 16),
-                    item.ext_address == ext_address,
-                    (item.type == ScanResult.TYPE_DISCOVERY_SCAN) or (item.joinable == joinable)]):
+                    int(item.channel, 16) == int(channel, 16), item.ext_address == ext_address,
+                    (item.type == ScanResult.TYPE_DISCOVERY_SCAN) or (item.joinable == joinable)
+                ])
+
+            if all([
+                    item.network_name == name,
+                    item.panid.strip() == panid.strip(),
+                    item.xpanid.strip() == xpanid.strip(),
+                    int(item.channel, 16) == int(channel, 16), item.ext_address == ext_address,
+                (item.type == ScanResult.TYPE_DISCOVERY_SCAN) or (item.joinable == joinable)
+            ]):
                 return True
 
     return False
@@ -430,47 +442,48 @@ def parse_list(list_string):
     """
     # List string example (get(WPAN_IP6_ALL_ADDRESSES) output):
     #
-    # '[\n
+    # `[\n
     # \t"fdf4:5632:4940:0:8798:8701:85d4:e2be     prefix_len:64   origin:ncp      valid:forever   preferred:forever"\n
     # \t"fe80::2092:9358:97ea:71c6                prefix_len:64   origin:ncp      valid:forever   preferred:forever"\n
-    # ]'
+    # ]`
     #
-    # We split the lines ('\n' as separator) and skip the first and last lines which are '['  and ']'.
-    # For each line, skip the first two characters (which are '\t"') and last character ('"'), then split the string
+    # We split the lines (`\n` as separator) and skip the first and last lines which are `[` and `]`.
+    # For each line, skip the first two characters (which are `\t"`) and last character (`"`), then split the string
     # using whitespace as separator. The first entry is the IPv6 address.
     #
-    return [line[2:-1].split()[0] for line in list_string.split('\n')[1:-1]]
+    return [line[2:-1].split()[0] for line in list_string.split("\n")[1:-1]]
 
 
 class OnMeshPrefix(object):
-    """ This object encapsulates an on-mesh prefix"""
+    """This object encapsulates an on-mesh prefix.
+    """
 
     def __init__(self, text):
 
         # Example of expected text:
         #
-        # '\t"fd00:abba:cafe::       prefix_len:64   origin:user     stable:yes flags:0x31'
-        # ' [on-mesh:1 def-route:0 config:0 dhcp:0 slaac:1 pref:1 prio:med] rloc:0x0000"'
+        # `\t"fd00:abba:cafe::       prefix_len:64   origin:user     stable:yes flags:0x31`
+        # ` [on-mesh:1 def-route:0 config:0 dhcp:0 slaac:1 pref:1 prio:med] rloc:0x0000"`
 
-        m = re.match('\t"([0-9a-fA-F:]+)\s*prefix_len:(\d+)\s+origin:(\w*)\s+stable:(\w*).* \[' +
-                    'on-mesh:(\d)\s+def-route:(\d)\s+config:(\d)\s+dhcp:(\d)\s+slaac:(\d)\s+pref:(\d)\s+prio:(\w*)\]' +
-                    '\s+rloc:(0x[0-9a-fA-F]+)',
-                     text)
+        m = re.match(
+            r"\t\"([0-9a-fA-F:]+)\s*prefix_len:(\d+)\s+origin:(\w*)\s+stable:(\w*).* \[" +
+            r"on-mesh:(\d)\s+def-route:(\d)\s+config:(\d)\s+dhcp:(\d)\s+slaac:(\d)\s+pref:(\d)\s+prio:(\w*)\]" +
+            r"\s+rloc:(0x[0-9a-fA-F]+)", text)
         wpan_util.verify(m is not None)
         data = m.groups()
 
-        self._prefix     = data[0]
+        self._prefix = data[0]
         self._prefix_len = data[1]
-        self._origin     = data[2]
-        self._stable     = (data[3] == 'yes')
-        self._on_mesh    = (data[4] == '1')
-        self._def_route  = (data[5] == '1')
-        self._config     = (data[6] == '1')
-        self._dhcp       = (data[7] == '1')
-        self._slaac      = (data[8] == '1')
-        self._preferred  = (data[9] == '1')
-        self._priority   = (data[10])
-        self._rloc16     = (data[11])
+        self._origin = data[2]
+        self._stable = (data[3] == "yes")
+        self._on_mesh = (data[4] == "1")
+        self._def_route = (data[5] == "1")
+        self._config = (data[6] == "1")
+        self._dhcp = (data[7] == "1")
+        self._slaac = (data[8] == "1")
+        self._preferred = (data[9] == "1")
+        self._priority = (data[10])
+        self._rloc16 = (data[11])
 
     @property
     def prefix(self):
@@ -513,9 +526,9 @@ class OnMeshPrefix(object):
         return self._rloc16
 
     def __repr__(self):
-        return 'OnMeshPrefix({})'.format(self.__dict__)
+        return "OnMeshPrefix({})".format(self.__dict__)
 
 
 def parse_on_mesh_prefix_result(on_mesh_prefix_list):
     """ Parses on-mesh prefix list string and returns an array of `OnMeshPrefix` objects"""
-    return [ OnMeshPrefix(item) for item in on_mesh_prefix_list.split('\n')[1:-1]]
+    return [OnMeshPrefix(item) for item in on_mesh_prefix_list.split("\n")[1:-1]]

--- a/silk/tools/wpan_util.py
+++ b/silk/tools/wpan_util.py
@@ -35,12 +35,13 @@ _is_in_verify_within = False
 
 
 def verify(condition):
-    """Verifies that a `condition` is true, otherwise raises a VerifyError"""
+    """Verifies that a `condition` is true, otherwise raises a VerifyError.
+    """
     global _is_in_verify_within
     if not condition:
         calling_frame = inspect.currentframe().f_back
-        error_message = 'verify() failed at line {} in "{}"'.format(calling_frame.f_lineno,
-                                                                    calling_frame.f_code.co_filename)
+        error_message = "verify() failed at line {} in \"{}\"".format(calling_frame.f_lineno,
+                                                                      calling_frame.f_code.co_filename)
         if not _is_in_verify_within:
             logger.error(error_message)
         raise VerifyError(error_message)
@@ -48,8 +49,8 @@ def verify(condition):
 
 def verify_within(condition_checker_func, wait_time, delay_time=0.1):
     """Verifies that a given function `condition_checker_func` passes successfully within a given wait timeout.
-       `wait_time` is maximum time waiting for condition_checker to pass (in seconds).
-       `delay_time` specifies a delay interval added between failed attempts (in seconds).
+        `wait_time` is maximum time waiting for condition_checker to pass (in seconds).
+        `delay_time` specifies a delay interval added between failed attempts (in seconds).
     """
     global _is_in_verify_within
     start_time = time.time()
@@ -58,10 +59,10 @@ def verify_within(condition_checker_func, wait_time, delay_time=0.1):
     while True:
         try:
             condition_checker_func()
-        except VerifyError as e:
+        except VerifyError:
             if time.time() - start_time > wait_time:
-                logger.error('Took too long to pass the condition ({}>{} sec)'
-                             .format(time.time() - start_time, wait_time))
+                logger.error("Took too long to pass the condition ({}>{} sec)".format(
+                    time.time() - start_time, wait_time))
                 raise
         except BaseException:
             raise
@@ -74,8 +75,7 @@ def verify_within(condition_checker_func, wait_time, delay_time=0.1):
 
 
 def verify_address(node_list, prefix):
-    """
-    This function verifies that all nodes in the `node_list` contain an IPv6 address with the given `prefix`.
+    """This function verifies that all nodes in the `node_list` contain an IPv6 address with the given `prefix`.
     """
     for node in node_list:
         all_addrs = wpan_table_parser.parse_list(node.get(wpan.WPAN_IP6_ALL_ADDRESSES))
@@ -83,18 +83,25 @@ def verify_address(node_list, prefix):
 
 
 def verify_no_address(node_list, prefix):
-    """
-    This function verifies that none of nodes in the `node_list` contain an IPv6 address with the given `prefix`.
+    """This function verifies that none of nodes in the `node_list` contain an IPv6 address with the given `prefix`.
     """
     for node in node_list:
         all_addrs = wpan_table_parser.parse_list(node.get(wpan.WPAN_IP6_ALL_ADDRESSES))
         verify(all([not addr.startswith(prefix[:-1]) for addr in all_addrs]))
 
 
-def verify_prefix(node_list, prefix, prefix_len=64, stable=True, priority='med', on_mesh=False, slaac=False,
-                  dhcp=False, configure=False, default_route=False, preferred=True):
-    """
-    This function verifies that the `prefix` is present on all the nodes in the `node_list`.
+def verify_prefix(node_list,
+                  prefix,
+                  prefix_len=64,
+                  stable=True,
+                  priority="med",
+                  on_mesh=False,
+                  slaac=False,
+                  dhcp=False,
+                  configure=False,
+                  default_route=False,
+                  preferred=True):
+    """This function verifies that the `prefix` is present on all the nodes in the `node_list`.
     """
     for node in node_list:
         prefixes = wpan_table_parser.parse_on_mesh_prefix_result(node.get(wpan.WPAN_THREAD_ON_MESH_PREFIXES))
@@ -114,8 +121,17 @@ def verify_prefix(node_list, prefix, prefix_len=64, stable=True, priority='med',
             raise VerifyError("Did not find prefix {} on node {}".format(prefix, node))
 
 
-def verify_correct_prefix_among_similar_prefixes(node_list, prefix, prefix_len=64, stable=True, priority='med', on_mesh=False, slaac=False,
-                        dhcp=False, configure=False, default_route=False, preferred=False):
+def verify_correct_prefix_among_similar_prefixes(node_list,
+                                                 prefix,
+                                                 prefix_len=64,
+                                                 stable=True,
+                                                 priority="med",
+                                                 on_mesh=False,
+                                                 slaac=False,
+                                                 dhcp=False,
+                                                 configure=False,
+                                                 default_route=False,
+                                                 preferred=False):
     """
     This function verifies that the `prefix` with specified flags is present on all nodes in the `node_list`
     by checking each and every prefix in the prefixes list till a match is found or the list is exhausted.
@@ -125,22 +141,16 @@ def verify_correct_prefix_among_similar_prefixes(node_list, prefix, prefix_len=6
         prefixes = wpan_table_parser.parse_on_mesh_prefix_result(node.get(wpan.WPAN_THREAD_ON_MESH_PREFIXES))
         for p in prefixes:
             if p.prefix == prefix:
-                if (int(p.prefix_len) == prefix_len and
-                        p.is_stable() == stable and
-                        p.is_on_mesh() == on_mesh and
-                        p.is_def_route() == default_route and
-                        p.is_slaac() == slaac and p.is_dhcp() == dhcp and
-                        p.is_config() == configure and
-                        p.is_preferred() == preferred and
-                        p.priority == priority):
+                if (int(p.prefix_len) == prefix_len and p.is_stable() == stable and p.is_on_mesh() == on_mesh and
+                        p.is_def_route() == default_route and p.is_slaac() == slaac and p.is_dhcp() == dhcp and
+                        p.is_config() == configure and p.is_preferred() == preferred and p.priority == priority):
                     break
         else:
             raise VerifyError("Did not find prefix {} on node {}".format(prefix, node.name))
 
 
 def verify_no_prefix(node_list, prefix):
-    """
-    This function verifies that the `prefix` is NOT present on any node in the `node_list`.
+    """This function verifies that the `prefix` is NOT present on any node in the `node_list`.
     """
     for node in node_list:
         prefixes = wpan_table_parser.parse_on_mesh_prefix_result(node.get(wpan.WPAN_THREAD_ON_MESH_PREFIXES))
@@ -148,19 +158,27 @@ def verify_no_prefix(node_list, prefix):
             verify(not p.prefix == prefix)
 
 
-def verify_prefix_with_rloc16(node_list, prefix, rloc16, prefix_len=64, stable=True, priority='med', on_mesh=False,
-                  slaac=False, dhcp=False, configure=False, default_route=False, preferred=True):
+def verify_prefix_with_rloc16(node_list,
+                              prefix,
+                              rloc16,
+                              prefix_len=64,
+                              stable=True,
+                              priority="med",
+                              on_mesh=False,
+                              slaac=False,
+                              dhcp=False,
+                              configure=False,
+                              default_route=False,
+                              preferred=True):
     """
     This function verifies that the `prefix` is present on all the nodes in the `node_list`. It also verifies
-     that the `prefix` is associated with the given `rloc16` (as an integer).
+        that the `prefix` is associated with the given `rloc16` (as an integer).
     """
     for node in node_list:
-        prefixes = wpan_table_parser.parse_on_mesh_prefix_result(
-            node.get(wpan.WPAN_THREAD_ON_MESH_PREFIXES))
+        prefixes = wpan_table_parser.parse_on_mesh_prefix_result(node.get(wpan.WPAN_THREAD_ON_MESH_PREFIXES))
 
         for p in prefixes:
-            if (p.prefix == prefix and p.origin == "ncp" and
-                    int(p.rloc16(), 0) == rloc16):
+            if (p.prefix == prefix and p.origin == "ncp" and int(p.rloc16(), 0) == rloc16):
                 verify(int(p.prefix_len) == prefix_len)
                 verify(p.is_stable() == stable)
                 verify(p.is_on_mesh() == on_mesh)
@@ -181,19 +199,16 @@ def verify_no_prefix_with_rloc16(node_list, prefix, rloc16):
     given `rloc16`.
     """
     for node in node_list:
-        prefixes = wpan_table_parser.parse_on_mesh_prefix_result(
-            node.get(wpan.WPAN_THREAD_ON_MESH_PREFIXES))
+        prefixes = wpan_table_parser.parse_on_mesh_prefix_result(node.get(wpan.WPAN_THREAD_ON_MESH_PREFIXES))
 
         for p in prefixes:
-            if (p.prefix == prefix and p.origin == "ncp" and
-                    int(p.rloc16(), 0) == rloc16):
-                raise VerifyError("Did find prefix {} with rloc16 {} on node {}"
-                                  .format(prefix, hex(rloc16), node.name))
+            if (p.prefix == prefix and p.origin == "ncp" and int(p.rloc16(), 0) == rloc16):
+                raise VerifyError("Did find prefix {} with rloc16 {} on node {}".format(
+                    prefix, hex(rloc16), node.name))
 
 
 def check_neighbor_table(node, neighbors):
-    """
-    This function verifies that the neighbor table of a given `node` contains the node in the `neighbors` list.
+    """This function verifies that the neighbor table of a given `node` contains the node in the `neighbors` list.
     """
     neighbor_table = wpan_table_parser.parse_neighbor_table_result(node.get(wpan.WPAN_THREAD_NEIGHBOR_TABLE))
     for neighbor in neighbors:
@@ -202,22 +217,23 @@ def check_neighbor_table(node, neighbors):
             if entry.ext_address == ext_addr:
                 break
         else:
-            raise VerifyError('Failed to find a neighbor entry for extended address {} in table'.format(ext_addr))
+            raise VerifyError("Failed to find a neighbor entry for extended address {} in table".format(ext_addr))
 
 
 def check_parent_on_child_and_childtable_on_parent(parent, children):
-    """Check parent on each child and on parent verify all children are present """
+    """Check parent on each child and on parent verify all children are present.
+    """
 
     # Get parent's extended address
     parent_ext_addr = parent.getprop(wpan.WPAN_EXT_ADDRESS)[1:-1]
 
     # Verify parent on children
-    for i, child in enumerate(children):
+    for child in children:
         # get the extended address(it's length is always 16) of the parent from child
         thread_parent = child.getprop(wpan.WPAN_THREAD_PARENT)[1:17]
         verify(parent_ext_addr == thread_parent)
-        logger.info("***** parent {} has extended address: {}, child {} selected parent: {} *****".
-                    format(parent.name, parent_ext_addr, child.name, thread_parent))
+        logger.info("***** parent {} has extended address: {}, child {} selected parent: {} *****".format(
+            parent.name, parent_ext_addr, child.name, thread_parent))
 
     # verify all children are present in selected parent's childtable
     child_table = parent.wpanctl("get", "get " + wpan.WPAN_THREAD_CHILD_TABLE, 2)
@@ -240,17 +256,18 @@ def check_parent_on_child_and_childtable_on_parent(parent, children):
 
 
 def check_unselected_parent(parent, children):
-    """Verify no children are attached to to this parent """
+    """Verify no children are attached to to this parent.
+    """
 
     # Get unselected parent's extended address
     parent_ext_addr = parent.getprop(wpan.WPAN_EXT_ADDRESS)[1:-1]
 
     # Verify that no children are attached to this parent
-    for i, child in enumerate(children):
+    for child in children:
         # get the extended address(it's length is always 16) of the parent from child
         thread_parent = child.getprop(wpan.WPAN_THREAD_PARENT)[1:17]
-        logger.info("*** unselected parent {} has extended address: {}, child {}'s parent: {} ***".
-                    format(parent.name, parent_ext_addr, child.name, thread_parent))
+        logger.info("*** unselected parent {} has extended address: {}, child {}'s parent: {} ***".format(
+            parent.name, parent_ext_addr, child.name, thread_parent))
         verify(parent_ext_addr != thread_parent)
 
     child_table_on_unselected_parent = parent.wpanctl("get", "get " + wpan.WPAN_THREAD_CHILD_TABLE, 2)

--- a/silk/unit_tests/mock_device.py
+++ b/silk/unit_tests/mock_device.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""This module contains mock device classes for tests.
+"""
 
 import configparser
 import logging
@@ -20,114 +22,110 @@ from silk.hw.hw_module import HwModule
 from silk.node.fifteen_four_dev_board import FifteenFourDevBoardNode, ThreadDevBoard
 from silk.utils import signal
 
+
 class MockHwModule(HwModule):
-  """Mock HwModule for unit testing.
-  """
-  def __init__(self, name: str, node_id: int):
-    """Initialize a mock HwModule.
-
-    Args:
-      name (str): name of the node.
-      node_id (int): ID of the node.
+    """Mock HwModule for unit testing.
     """
-    super().__init__(name=name,
-                     parser=configparser.ConfigParser(),
-                     node_id=node_id,
-                     port=f"/dev/tty{node_id}")
-    self._model = "Mock"
-    self._dut_serial = "683" + str(random.getrandbits(24))
-    self._layout_center = 100, 100
-    self._layout_radius = 100
-    self._layout_x = None
-    self._layout_y = None
-  
-  def set_otns_vis_position(self, x: int, y: int):
-    """Set mock OTNS visualization position.
 
-    Args:
-      x (int): x coordinate of visualization position.
-      y (int): y coordinate of visualization position.
-    """
-    self._layout_x = x
-    self._layout_y = y
-  
-  def get_otns_vis_position(self):
-    """Get mock OTNS visualization position.
+    def __init__(self, name: str, node_id: int):
+        """Initialize a mock HwModule.
 
-    Raises:
-      ValueError: if OTNS visualization position is not set.
+        Args:
+            name (str): name of the node.
+            node_id (int): ID of the node.
+        """
+        super().__init__(name=name, parser=configparser.ConfigParser(), node_id=node_id, port=f"/dev/tty{node_id}")
+        self._model = "Mock"
+        self._dut_serial = "683" + str(random.getrandbits(24))
+        self._layout_center = 100, 100
+        self._layout_radius = 100
+        self._layout_x = None
+        self._layout_y = None
 
-    Returns:
-      Tuple[int, int]: OTNS visualization position coordinates.
-    """
-    if self._layout_x is None or self._layout_y is None:
-      raise ValueError("Node position must have x and y coordinates.")
+    def set_otns_vis_position(self, x: int, y: int):
+        """Set mock OTNS visualization position.
 
-    return self._layout_x, self._layout_y
+        Args:
+            x (int): x coordinate of visualization position.
+            y (int): y coordinate of visualization position.
+        """
+        self._layout_x = x
+        self._layout_y = y
 
-  def set_otns_layout_parameter(self, x: int, y: int, radius: int):
-    """Set mock OTNS visualization auto layout parameter.
+    def get_otns_vis_position(self):
+        """Get mock OTNS visualization position.
 
-    Args:
-      x (int): x coordinate of visualization center.
-      y (int): y coordinate of visualization center.
-      radius (int): radius visualization circle.
-    """
-    self._layout_center = x, y
-    self._layout_radius = radius
+        Raises:
+            ValueError: if OTNS visualization position is not set.
+
+        Returns:
+            Tuple[int, int]: OTNS visualization position coordinates.
+        """
+        if self._layout_x is None or self._layout_y is None:
+            raise ValueError("Node position must have x and y coordinates.")
+
+        return self._layout_x, self._layout_y
+
+    def set_otns_layout_parameter(self, x: int, y: int, radius: int):
+        """Set mock OTNS visualization auto layout parameter.
+
+        Args:
+            x (int): x coordinate of visualization center.
+            y (int): y coordinate of visualization center.
+            radius (int): radius visualization circle.
+        """
+        self._layout_center = x, y
+        self._layout_radius = radius
 
 
 class MockThreadDevBoard(ThreadDevBoard):
-  """Mock ThreadDevBoard for unit testing.
+    """Mock ThreadDevBoard for unit testing.
 
-  Attributes:
-    _hwModel (str): device hardware model.
-  """
-  _hwModel = "Mock"
-
-  def __init__(self, name: str, node_id: int):
-    """Initialize a mock ThreadDevBoard.
-
-    Args:
-      name (str): name of the node.
-      node_id (int): ID of the node.
+    Attributes:
+        _hw_model (str): device hardware model.
     """
-    mock_device = MockHwModule(name, node_id)
-    FifteenFourDevBoardNode.__init__(
-        self,
-        virtual=True,
-        device=mock_device,
-        device_path=mock_device.port())
-    if self.logger:
-      self.logger.setLevel(logging.WARN)
+    _hw_model = "Mock"
 
-  @property
-  def id(self) -> int:
-    return self.device.get_otns_vis_node_id()
+    def __init__(self, name: str, node_id: int):
+        """Initialize a mock ThreadDevBoard.
 
-  @property
-  def x(self) -> int:
-    return self.device.get_otns_vis_position()[0]
+        Args:
+            name (str): name of the node.
+            node_id (int): ID of the node.
+        """
+        mock_device = MockHwModule(name, node_id)
+        FifteenFourDevBoardNode.__init__(self, virtual=True, device=mock_device, device_path=mock_device.port())
+        if self.logger:
+            self.logger.setLevel(logging.WARN)
 
-  @property
-  def y(self) -> int:
-    return self.device.get_otns_vis_position()[1]
+    @property
+    def id(self) -> int:
+        return self.device.get_otns_vis_node_id()
+
+    @property
+    def x(self) -> int:
+        return self.device.get_otns_vis_position()[0]
+
+    @property
+    def y(self) -> int:
+        return self.device.get_otns_vis_position()[1]
 
 
 class MockWpantundProcess(signal.Publisher):
-  """Mock signal publisher that act as wpantund process.
-  """
-  def __init__(self):
-    """Initialize a mock wpantund process.
+    """Mock signal publisher that act as wpantund process.
     """
-    super().__init__()
-    self._process_id = random.getrandbits(16)
-    self._prefix = f"wpantund[{self._process_id}]: NCP => [OTNS] "
-  
-  def emit_status(self, status: str):
-    """Emit a status string to subscribers.
 
-    Args:
-      status (str): status to emit.
-    """
-    self.emit(line=self._prefix + status)
+    def __init__(self):
+        """Initialize a mock wpantund process.
+        """
+        super().__init__()
+        self._process_id = random.getrandbits(16)
+        self._prefix = f"wpantund[{self._process_id}]: NCP => [OTNS] "
+
+    def emit_status(self, status: str):
+        """Emit a status string to subscribers.
+
+        Args:
+            status (str): status to emit.
+        """
+        self.emit(line=self._prefix + status)

--- a/silk/unit_tests/silk_replay_test.py
+++ b/silk/unit_tests/silk_replay_test.py
@@ -11,20 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Sample script to run SilkReplayer to replay a log.
+"""
 
 from silk.tests import silk_replay
 
-CONFIG_PATH = '/opt/openthread_test/'
-LOG_PATH = '/opt/openthread_test/results/'
+CONFIG_PATH = "/opt/openthread_test/"
+LOG_PATH = "/opt/openthread_test/results/"
 
 argv = [
-    'tests/silk_replay.py',
-    '-r', LOG_PATH,
-    '-v2',
-    '-c', CONFIG_PATH + 'hwconfig.ini',
-    '-s', 'localhost',
-    '-p', '20',
-    '/home/pi/Documents/silk.log'
+    "tests/silk_replay.py", "-r", LOG_PATH, "-v2", "-c", CONFIG_PATH + "hwconfig.ini", "-s", "localhost", "-p", "20",
+    "/home/pi/Documents/silk.log"
 ]
 
 silk_replay.SilkReplayer(argv=argv)

--- a/silk/unit_tests/silk_run_test.py
+++ b/silk/unit_tests/silk_run_test.py
@@ -11,29 +11,27 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Sample script to run SilkRunner to run testcases.
+"""
 
 import datetime
 import os
 
 from silk.tests import silk_run
 
-RESULT_LOG_PATH = '/opt/openthread_test/results/' + 'silk_run_' + \
-                  datetime.datetime.today().strftime('%m-%d') + '/'
-CONFIG_PATH = '/opt/openthread_test/'
+RESULT_LOG_PATH = "/opt/openthread_test/results/" + "silk_run_" + \
+    datetime.datetime.today().strftime("%m-%d") + "/"
+CONFIG_PATH = "/opt/openthread_test/"
 
-os.chdir('/home/pi/silk/silk/tests/')
+os.chdir("/home/pi/silk/silk/tests/")
 
-timestamp = datetime.datetime.today().strftime('%m-%d-%H:%M')
+timestamp = datetime.datetime.today().strftime("%m-%d-%H:%M")
 
-run_log_path = RESULT_LOG_PATH + 'test_run_on_' + timestamp + '/'
+run_log_path = RESULT_LOG_PATH + "test_run_on_" + timestamp + "/"
 
 argv = [
-    'tests/silk_run.py',
-    '-v2',
-    '-c', CONFIG_PATH + 'hwconfig.ini',
-    '-d', run_log_path,
-    '-s', 'localhost',
-    'ot_test_*.py'
+    "tests/silk_run.py", "-v2", "-c", CONFIG_PATH + "hwconfig.ini", "-d", run_log_path, "-s", "localhost",
+    "ot_test_*.py"
 ]
 
 silk_run.SilkRunner(argv=argv)

--- a/silk/unit_tests/test_otns.py
+++ b/silk/unit_tests/test_otns.py
@@ -23,408 +23,398 @@ from silk.tools.otns_manager import OtnsManager
 from silk.unit_tests.testcase import SilkTestCase
 from silk.unit_tests.mock_device import MockThreadDevBoard, MockWpantundProcess
 
+
 class OTNSIntegrationTest(SilkTestCase):
-  """Silk integration test case for OTNS.
+    """Silk integration test case for OTNS.
   """
-  def setUp(self) -> None:
-    """Test method set up.
-    """
-    self.ns = OTNS(otns_args=[
-        "-raw", "-real",
-        "-ot-cli", "otns-silk-proxy",
-        "-listen", ":9000",
-        "-log", "debug"])
-    # wait for OTNS gRPC server to start
-    time.sleep(0.3)
-    self.manager = OtnsManager("localhost",
-                               self.logger.getChild("OtnsManager"))
-    self.manager.wait_for_grpc_channel_ready(10)
 
-  def tearDown(self) -> None:
-    """Test method tear down.
+    def setUp(self) -> None:
+        """Test method set up.
     """
-    self.manager.unsubscribe_from_all_nodes()
-    self.manager.remove_all_nodes()
-    self.ns.close()
-    # wait for OTNS gRPC server to stop
-    time.sleep(0.2)
+        self.ns = OTNS(otns_args=["-raw", "-real", "-ot-cli", "otns-silk-proxy", "-listen", ":9000", "-log", "debug"])
+        # wait for OTNS gRPC server to start
+        time.sleep(0.3)
+        self.manager = OtnsManager("localhost", self.logger.getChild("OtnsManager"))
+        self.manager.wait_for_grpc_channel_ready(10)
 
-  def assert_device_positions(self,
-                              nodes_info: Dict[int, Dict[str, Any]],
-                              expected_coords: Dict[int, Tuple[int, int]]):
-    """Helper method to assert auto layout position devices coordinates.
+    def tearDown(self) -> None:
+        """Test method tear down.
+    """
+        self.manager.unsubscribe_from_all_nodes()
+        self.manager.remove_all_nodes()
+        self.ns.close()
+        # wait for OTNS gRPC server to stop
+        time.sleep(0.2)
+
+    def assert_device_positions(self, nodes_info: Dict[int, Dict[str, Any]], expected_coords: Dict[int, Tuple[int,
+                                                                                                              int]]):
+        """Helper method to assert auto layout position devices coordinates.
 
     Args:
       nodes_info (Dict[int, Dict[str, Any]]): nodes info dictionary
       expected_coords (Dict[int, Tuple[int, int]]): dict mapping device
         id to coodinates to check
     """
-    for device_id, coords in expected_coords.items():
-      self.assertAlmostEqual(nodes_info[device_id]["x"], coords[0], delta=1)
-      self.assertAlmostEqual(nodes_info[device_id]["y"], coords[1], delta=1)
+        for device_id, coords in expected_coords.items():
+            self.assertAlmostEqual(nodes_info[device_id]["x"], coords[0], delta=1)
+            self.assertAlmostEqual(nodes_info[device_id]["y"], coords[1], delta=1)
 
-  def testAddDevice(self):
-    """Test adding device.
+    def testAddDevice(self):
+        """Test adding device.
     """
-    ns = self.ns
-    manager = self.manager
+        ns = self.ns
+        manager = self.manager
 
-    device = MockThreadDevBoard("device", 1)
-    manager.add_node(device)
-    ns.go(0.1)
-    self.assertEqual(len(ns.nodes()), 1)
+        device = MockThreadDevBoard("device", 1)
+        manager.add_node(device)
+        ns.go(0.1)
+        self.assertEqual(len(ns.nodes()), 1)
 
-  def testRemoveDevice(self):
-    """Test removing device.
+    def testRemoveDevice(self):
+        """Test removing device.
     """
-    ns = self.ns
-    manager = self.manager
+        ns = self.ns
+        manager = self.manager
 
-    device = MockThreadDevBoard("device", 1)
-    manager.add_node(device)
-    ns.go(0.1)
-    self.assertEqual(len(ns.nodes()), 1)
+        device = MockThreadDevBoard("device", 1)
+        manager.add_node(device)
+        ns.go(0.1)
+        self.assertEqual(len(ns.nodes()), 1)
 
-    manager.remove_node(device)
-    ns.go(0.1)
-    self.assertEqual(len(ns.nodes()), 0)
+        manager.remove_node(device)
+        ns.go(0.1)
+        self.assertEqual(len(ns.nodes()), 0)
 
-  def testSetSpeed(self):
-    """Test setting speed display.
+    def testSetSpeed(self):
+        """Test setting speed display.
     """
-    ns = self.ns
-    manager = self.manager
+        ns = self.ns
+        manager = self.manager
 
-    speed = random.randint(2, 20)
-    manager.set_replay_speed(speed)
-    self.assertAlmostEqual(ns.speed, speed)
+        speed = random.randint(2, 20)
+        manager.set_replay_speed(speed)
+        self.assertAlmostEqual(ns.speed, speed)
 
-    speed = random.randint(21, 40)
-    manager.set_replay_speed(speed)
-    self.assertAlmostEqual(ns.speed, speed)
+        speed = random.randint(21, 40)
+        manager.set_replay_speed(speed)
+        self.assertAlmostEqual(ns.speed, speed)
 
-  def testAddFixedPositionDevices(self):
-    """Test adding fixed position nodes.
+    def testAddFixedPositionDevices(self):
+        """Test adding fixed position nodes.
     """
-    def assert_device_fixed_positions(devices: List[MockThreadDevBoard]):
-      """Helper method to assert fixed position devices coordinates.
+
+        def assert_device_fixed_positions(devices: List[MockThreadDevBoard]):
+            """Helper method to assert fixed position devices coordinates.
 
       Args:
         devices (List[MockThreadDevBoard]): list of devices to check
       """
-      for device in devices:
-        self.assertEqual(nodes_info[device.id]["x"], device.x)
-        self.assertEqual(nodes_info[device.id]["y"], device.y)
+            for device in devices:
+                self.assertEqual(nodes_info[device.id]["x"], device.x)
+                self.assertEqual(nodes_info[device.id]["y"], device.y)
 
-    ns = self.ns
-    manager = self.manager
+        ns = self.ns
+        manager = self.manager
 
-    device_1_id, device_2_id = random.randint(1, 10), random.randint(11, 20)
-    device_1 = MockThreadDevBoard("device_1", device_1_id)
-    device_2 = MockThreadDevBoard("device_2", device_2_id)
+        device_1_id, device_2_id = random.randint(1, 10), random.randint(11, 20)
+        device_1 = MockThreadDevBoard("device_1", device_1_id)
+        device_2 = MockThreadDevBoard("device_2", device_2_id)
 
-    device_1_x, device_1_y = random.randint(100, 200), random.randint(100, 200)
-    device_2_x, device_2_y = random.randint(100, 200), random.randint(100, 200)
-    device_1.device.set_otns_vis_position(device_1_x, device_1_y)
-    device_2.device.set_otns_vis_position(device_2_x, device_2_y)
+        device_1_x, device_1_y = random.randint(100, 200), random.randint(100, 200)
+        device_2_x, device_2_y = random.randint(100, 200), random.randint(100, 200)
+        device_1.device.set_otns_vis_position(device_1_x, device_1_y)
+        device_2.device.set_otns_vis_position(device_2_x, device_2_y)
 
-    manager.add_node(device_1)
-    manager.add_node(device_2)
-    ns.go(0.1)
+        manager.add_node(device_1)
+        manager.add_node(device_2)
+        ns.go(0.1)
 
-    nodes_info = ns.nodes()
-    self.assertEqual(len(nodes_info), 2)
-    assert_device_fixed_positions([device_1, device_2])
+        nodes_info = ns.nodes()
+        self.assertEqual(len(nodes_info), 2)
+        assert_device_fixed_positions([device_1, device_2])
 
-    device_3_id = random.randint(21, 30)
-    device_3 = MockThreadDevBoard("device_3", device_3_id)
+        device_3_id = random.randint(21, 30)
+        device_3 = MockThreadDevBoard("device_3", device_3_id)
 
-    device_3_x, device_3_y = random.randint(100, 200), random.randint(100, 200)
-    device_3.device.set_otns_vis_position(device_3_x, device_3_y)
+        device_3_x, device_3_y = random.randint(100, 200), random.randint(100, 200)
+        device_3.device.set_otns_vis_position(device_3_x, device_3_y)
 
-    manager.add_node(device_3)
-    ns.go(0.1)
+        manager.add_node(device_3)
+        ns.go(0.1)
 
-    nodes_info = ns.nodes()
-    self.assertEqual(len(nodes_info), 3)
-    assert_device_fixed_positions([device_1, device_2, device_3])
+        nodes_info = ns.nodes()
+        self.assertEqual(len(nodes_info), 3)
+        assert_device_fixed_positions([device_1, device_2, device_3])
 
-  def testAddAutoLayoutDevices(self):
-    """Test adding auto layout nodes.
+    def testAddAutoLayoutDevices(self):
+        """Test adding auto layout nodes.
     """
-    ns = self.ns
-    manager = self.manager
+        ns = self.ns
+        manager = self.manager
 
-    layout_center_x = random.randint(100, 200)
-    layout_center_y = random.randint(100, 200)
-    layout_radius = random.randint(50, 100)
+        layout_center_x = random.randint(100, 200)
+        layout_center_y = random.randint(100, 200)
+        layout_radius = random.randint(50, 100)
 
-    device_1_id = 1
-    device_2_id = 2
-    device_3_id = 3
-    device_4_id = 4
-    device_1 = MockThreadDevBoard("device_1", device_1_id)
-    device_2 = MockThreadDevBoard("device_2", device_2_id)
-    device_3 = MockThreadDevBoard("device_3", device_3_id)
-    device_4 = MockThreadDevBoard("device_4", device_4_id)
+        device_1_id = 1
+        device_2_id = 2
+        device_3_id = 3
+        device_4_id = 4
+        device_1 = MockThreadDevBoard("device_1", device_1_id)
+        device_2 = MockThreadDevBoard("device_2", device_2_id)
+        device_3 = MockThreadDevBoard("device_3", device_3_id)
+        device_4 = MockThreadDevBoard("device_4", device_4_id)
 
-    device_1.device.set_otns_layout_parameter(
-        layout_center_x, layout_center_y, layout_radius)
-    device_2.device.set_otns_layout_parameter(
-        layout_center_x, layout_center_y, layout_radius)
-    device_3.device.set_otns_layout_parameter(
-        layout_center_x, layout_center_y, layout_radius)
-    device_4.device.set_otns_layout_parameter(
-        layout_center_x, layout_center_y, layout_radius)
+        device_1.device.set_otns_layout_parameter(layout_center_x, layout_center_y, layout_radius)
+        device_2.device.set_otns_layout_parameter(layout_center_x, layout_center_y, layout_radius)
+        device_3.device.set_otns_layout_parameter(layout_center_x, layout_center_y, layout_radius)
+        device_4.device.set_otns_layout_parameter(layout_center_x, layout_center_y, layout_radius)
 
-    manager.add_node(device_1)
-    ns.go(0.1)
+        manager.add_node(device_1)
+        ns.go(0.1)
 
-    nodes_info = ns.nodes()
-    self.assertEqual(len(nodes_info), 1)
-    # placing the first node alone
-    expected_coords = {
-        device_1.id: (layout_center_x + layout_radius, layout_center_y)}
-    nodes_info = ns.nodes()
-    self.assert_device_positions(nodes_info, expected_coords)
+        nodes_info = ns.nodes()
+        self.assertEqual(len(nodes_info), 1)
+        # placing the first node alone
+        expected_coords = {device_1.id: (layout_center_x + layout_radius, layout_center_y)}
+        nodes_info = ns.nodes()
+        self.assert_device_positions(nodes_info, expected_coords)
 
-    manager.add_node(device_2)
-    ns.go(0.1)
+        manager.add_node(device_2)
+        ns.go(0.1)
 
-    nodes_info = ns.nodes()
-    self.assertEqual(len(nodes_info), 2)
-    # forming a horizontal line
-    expected_coords = {
-        device_1.id: (layout_center_x - layout_radius, layout_center_y),
-        device_2.id: (layout_center_x + layout_radius, layout_center_y)}
-    self.assert_device_positions(nodes_info, expected_coords)
+        nodes_info = ns.nodes()
+        self.assertEqual(len(nodes_info), 2)
+        # forming a horizontal line
+        expected_coords = {
+            device_1.id: (layout_center_x - layout_radius, layout_center_y),
+            device_2.id: (layout_center_x + layout_radius, layout_center_y)
+        }
+        self.assert_device_positions(nodes_info, expected_coords)
 
-    manager.add_node(device_3)
-    manager.add_node(device_4)
-    ns.go(0.1)
+        manager.add_node(device_3)
+        manager.add_node(device_4)
+        ns.go(0.1)
 
-    nodes_info = ns.nodes()
-    self.assertEqual(len(nodes_info), 4)
-    # forming a cross shape
-    expected_coords = {
-        device_1.id: (layout_center_x, layout_center_y + layout_radius),
-        device_2.id: (layout_center_x - layout_radius, layout_center_y),
-        device_3.id: (layout_center_x, layout_center_y - layout_radius),
-        device_4.id: (layout_center_x + layout_radius, layout_center_y)}
-    self.assert_device_positions(nodes_info, expected_coords)
+        nodes_info = ns.nodes()
+        self.assertEqual(len(nodes_info), 4)
+        # forming a cross shape
+        expected_coords = {
+            device_1.id: (layout_center_x, layout_center_y + layout_radius),
+            device_2.id: (layout_center_x - layout_radius, layout_center_y),
+            device_3.id: (layout_center_x, layout_center_y - layout_radius),
+            device_4.id: (layout_center_x + layout_radius, layout_center_y)
+        }
+        self.assert_device_positions(nodes_info, expected_coords)
 
-  def testRemoveAutoLayoutDevices(self):
-    """Test that removing nodes keeps other nodes stationary with auto layout.
+    def testRemoveAutoLayoutDevices(self):
+        """Test that removing nodes keeps other nodes stationary with auto layout.
     """
-    ns = self.ns
-    manager = self.manager
+        ns = self.ns
+        manager = self.manager
 
-    layout_center_x = random.randint(100, 200)
-    layout_center_y = random.randint(100, 200)
-    layout_radius = random.randint(50, 100)
+        layout_center_x = random.randint(100, 200)
+        layout_center_y = random.randint(100, 200)
+        layout_radius = random.randint(50, 100)
 
-    device_1_id = 1
-    device_2_id = 2
-    device_3_id = 3
-    device_4_id = 4
-    device_1 = MockThreadDevBoard("device_1", device_1_id)
-    device_2 = MockThreadDevBoard("device_2", device_2_id)
-    device_3 = MockThreadDevBoard("device_3", device_3_id)
-    device_4 = MockThreadDevBoard("device_4", device_4_id)
+        device_1_id = 1
+        device_2_id = 2
+        device_3_id = 3
+        device_4_id = 4
+        device_1 = MockThreadDevBoard("device_1", device_1_id)
+        device_2 = MockThreadDevBoard("device_2", device_2_id)
+        device_3 = MockThreadDevBoard("device_3", device_3_id)
+        device_4 = MockThreadDevBoard("device_4", device_4_id)
 
-    device_1.device.set_otns_layout_parameter(
-        layout_center_x, layout_center_y, layout_radius)
-    device_2.device.set_otns_layout_parameter(
-        layout_center_x, layout_center_y, layout_radius)
-    device_3.device.set_otns_layout_parameter(
-        layout_center_x, layout_center_y, layout_radius)
-    device_4.device.set_otns_layout_parameter(
-        layout_center_x, layout_center_y, layout_radius)
+        device_1.device.set_otns_layout_parameter(layout_center_x, layout_center_y, layout_radius)
+        device_2.device.set_otns_layout_parameter(layout_center_x, layout_center_y, layout_radius)
+        device_3.device.set_otns_layout_parameter(layout_center_x, layout_center_y, layout_radius)
+        device_4.device.set_otns_layout_parameter(layout_center_x, layout_center_y, layout_radius)
 
-    manager.add_node(device_1)
-    manager.add_node(device_2)
-    manager.add_node(device_3)
-    manager.add_node(device_4)
-    ns.go(0.1)
+        manager.add_node(device_1)
+        manager.add_node(device_2)
+        manager.add_node(device_3)
+        manager.add_node(device_4)
+        ns.go(0.1)
 
-    nodes_info = ns.nodes()
-    self.assertEqual(len(nodes_info), 4)
-    expected_coords = {
-        device_1.id: (layout_center_x, layout_center_y + layout_radius),
-        device_2.id: (layout_center_x - layout_radius, layout_center_y),
-        device_3.id: (layout_center_x, layout_center_y - layout_radius),
-        device_4.id: (layout_center_x + layout_radius, layout_center_y)}
-    self.assert_device_positions(nodes_info, expected_coords)
+        nodes_info = ns.nodes()
+        self.assertEqual(len(nodes_info), 4)
+        expected_coords = {
+            device_1.id: (layout_center_x, layout_center_y + layout_radius),
+            device_2.id: (layout_center_x - layout_radius, layout_center_y),
+            device_3.id: (layout_center_x, layout_center_y - layout_radius),
+            device_4.id: (layout_center_x + layout_radius, layout_center_y)
+        }
+        self.assert_device_positions(nodes_info, expected_coords)
 
-    manager.remove_node(device_4)
-    ns.go(0.1)
-    nodes_info = ns.nodes()
-    self.assertEqual(len(nodes_info), 3)
-    expected_coords = {
-        device_1.id: (layout_center_x, layout_center_y + layout_radius),
-        device_2.id: (layout_center_x - layout_radius, layout_center_y),
-        device_3.id: (layout_center_x, layout_center_y - layout_radius)}
-    self.assert_device_positions(nodes_info, expected_coords)
+        manager.remove_node(device_4)
+        ns.go(0.1)
+        nodes_info = ns.nodes()
+        self.assertEqual(len(nodes_info), 3)
+        expected_coords = {
+            device_1.id: (layout_center_x, layout_center_y + layout_radius),
+            device_2.id: (layout_center_x - layout_radius, layout_center_y),
+            device_3.id: (layout_center_x, layout_center_y - layout_radius)
+        }
+        self.assert_device_positions(nodes_info, expected_coords)
 
-    manager.remove_node(device_3)
-    ns.go(0.1)
-    nodes_info = ns.nodes()
-    self.assertEqual(len(nodes_info), 2)
-    expected_coords = {
-        device_1.id: (layout_center_x, layout_center_y + layout_radius),
-        device_2.id: (layout_center_x - layout_radius, layout_center_y)}
-    self.assert_device_positions(nodes_info, expected_coords)
+        manager.remove_node(device_3)
+        ns.go(0.1)
+        nodes_info = ns.nodes()
+        self.assertEqual(len(nodes_info), 2)
+        expected_coords = {
+            device_1.id: (layout_center_x, layout_center_y + layout_radius),
+            device_2.id: (layout_center_x - layout_radius, layout_center_y)
+        }
+        self.assert_device_positions(nodes_info, expected_coords)
 
-    manager.remove_node(device_2)
-    ns.go(0.1)
-    nodes_info = ns.nodes()
-    self.assertEqual(len(nodes_info), 1)
-    expected_coords = {
-        device_1.id: (layout_center_x, layout_center_y + layout_radius)}
-    self.assert_device_positions(nodes_info, expected_coords)
+        manager.remove_node(device_2)
+        ns.go(0.1)
+        nodes_info = ns.nodes()
+        self.assertEqual(len(nodes_info), 1)
+        expected_coords = {device_1.id: (layout_center_x, layout_center_y + layout_radius)}
+        self.assert_device_positions(nodes_info, expected_coords)
 
-    manager.add_node(device_2)
-    manager.remove_node(device_1)
-    ns.go(0.1)
-    nodes_info = ns.nodes()
-    self.assertEqual(len(nodes_info), 1)
-    expected_coords = {
-        device_2.id: (layout_center_x - layout_radius, layout_center_y)}
-    self.assert_device_positions(nodes_info, expected_coords)
+        manager.add_node(device_2)
+        manager.remove_node(device_1)
+        ns.go(0.1)
+        nodes_info = ns.nodes()
+        self.assertEqual(len(nodes_info), 1)
+        expected_coords = {device_2.id: (layout_center_x - layout_radius, layout_center_y)}
+        self.assert_device_positions(nodes_info, expected_coords)
 
-    manager.add_node(device_3)
-    manager.remove_node(device_2)
-    ns.go(0.1)
-    nodes_info = ns.nodes()
-    self.assertEqual(len(nodes_info), 1)
-    expected_coords = {
-        device_3.id: (layout_center_x, layout_center_y - layout_radius)}
-    self.assert_device_positions(nodes_info, expected_coords)
+        manager.add_node(device_3)
+        manager.remove_node(device_2)
+        ns.go(0.1)
+        nodes_info = ns.nodes()
+        self.assertEqual(len(nodes_info), 1)
+        expected_coords = {device_3.id: (layout_center_x, layout_center_y - layout_radius)}
+        self.assert_device_positions(nodes_info, expected_coords)
 
-    manager.add_node(device_4)
-    manager.remove_node(device_3)
-    ns.go(0.1)
-    nodes_info = ns.nodes()
-    self.assertEqual(len(nodes_info), 1)
-    expected_coords = {
-        device_4.id: (layout_center_x + layout_radius, layout_center_y)}
-    self.assert_device_positions(nodes_info, expected_coords)
+        manager.add_node(device_4)
+        manager.remove_node(device_3)
+        ns.go(0.1)
+        nodes_info = ns.nodes()
+        self.assertEqual(len(nodes_info), 1)
+        expected_coords = {device_4.id: (layout_center_x + layout_radius, layout_center_y)}
+        self.assert_device_positions(nodes_info, expected_coords)
 
-  def testUpdateExtaddr(self):
-    """Test updating node extended address.
+    def testUpdateExtaddr(self):
+        """Test updating node extended address.
 
     Also tests updating before the OTNS manager subscribes to the node.
     """
-    ns = self.ns
-    manager = self.manager
+        ns = self.ns
+        manager = self.manager
 
-    device_id = random.randint(1, 10)
-    device_extaddr = random.getrandbits(64)
-    device = MockThreadDevBoard("device", device_id)
-    wpantund_process = MockWpantundProcess()
-    device.wpantund_process = wpantund_process
+        device_id = random.randint(1, 10)
+        device_extaddr = random.getrandbits(64)
+        device = MockThreadDevBoard("device", device_id)
+        wpantund_process = MockWpantundProcess()
+        device.wpantund_process = wpantund_process
 
-    manager.add_node(device)
-    ns.go(0.1)
+        manager.add_node(device)
+        ns.go(0.1)
 
-    self.assertEqual(ns.nodes()[device.id]["extaddr"], device.id)
+        self.assertEqual(ns.nodes()[device.id]["extaddr"], device.id)
 
-    wpantund_process.emit_status(f"extaddr={device_extaddr:016x}")
-    ns.go(0.1)
+        wpantund_process.emit_status(f"extaddr={device_extaddr:016x}")
+        ns.go(0.1)
 
-    self.assertEqual(ns.nodes()[device.id]["extaddr"], device.id)
+        self.assertEqual(ns.nodes()[device.id]["extaddr"], device.id)
 
-    manager.subscribe_to_node(device)
-    wpantund_process.emit_status(f"extaddr={device_extaddr:016x}")
-    ns.go(0.1)
+        manager.subscribe_to_node(device)
+        wpantund_process.emit_status(f"extaddr={device_extaddr:016x}")
+        ns.go(0.1)
 
-    self.assertEqual(ns.nodes()[device.id]["extaddr"], device_extaddr)
+        self.assertEqual(ns.nodes()[device.id]["extaddr"], device_extaddr)
 
-  def testUpdateRLOC16(self):
-    """Test updating node RLOC16.
+    def testUpdateRLOC16(self):
+        """Test updating node RLOC16.
 
     Also tests updating before the OTNS manager subscribes to the node.
     """
-    ns = self.ns
-    manager = self.manager
+        ns = self.ns
+        manager = self.manager
 
-    device_id = random.randint(1, 10)
-    device_rloc16 = random.getrandbits(16)
-    device = MockThreadDevBoard("device", device_id)
-    wpantund_process = MockWpantundProcess()
-    device.wpantund_process = wpantund_process
+        device_id = random.randint(1, 10)
+        device_rloc16 = random.getrandbits(16)
+        device = MockThreadDevBoard("device", device_id)
+        wpantund_process = MockWpantundProcess()
+        device.wpantund_process = wpantund_process
 
-    manager.add_node(device)
-    ns.go(0.1)
+        manager.add_node(device)
+        ns.go(0.1)
 
-    original_rloc16 = ns.nodes()[device.id]["rloc16"]
+        original_rloc16 = ns.nodes()[device.id]["rloc16"]
 
-    wpantund_process.emit_status(f"rloc16={device_rloc16}")
-    ns.go(0.1)
+        wpantund_process.emit_status(f"rloc16={device_rloc16}")
+        ns.go(0.1)
 
-    self.assertEqual(ns.nodes()[device.id]["rloc16"], original_rloc16)
+        self.assertEqual(ns.nodes()[device.id]["rloc16"], original_rloc16)
 
-    manager.subscribe_to_node(device)
-    wpantund_process.emit_status(f"rloc16={device_rloc16}")
-    ns.go(0.1)
+        manager.subscribe_to_node(device)
+        wpantund_process.emit_status(f"rloc16={device_rloc16}")
+        ns.go(0.1)
 
-    self.assertEqual(ns.nodes()[device.id]["rloc16"], device_rloc16)
+        self.assertEqual(ns.nodes()[device.id]["rloc16"], device_rloc16)
 
-  def testFormPartition(self):
-    """Test forming a partition.
+    def testFormPartition(self):
+        """Test forming a partition.
     """
-    ns = self.ns
-    manager = self.manager
+        ns = self.ns
+        manager = self.manager
 
-    device_1_id = random.randint(1, 10)
-    device_1_parid = random.getrandbits(16)
-    device_1 = MockThreadDevBoard("device_1", device_1_id)
-    wpantund_process_1 = MockWpantundProcess()
-    device_1.wpantund_process = wpantund_process_1
+        device_1_id = random.randint(1, 10)
+        device_1_parid = random.getrandbits(16)
+        device_1 = MockThreadDevBoard("device_1", device_1_id)
+        wpantund_process_1 = MockWpantundProcess()
+        device_1.wpantund_process = wpantund_process_1
 
-    device_2_id = random.randint(11, 20)
-    device_2_parid = random.getrandbits(16)
-    device_2 = MockThreadDevBoard("device_2", device_2_id)
-    wpantund_process_2 = MockWpantundProcess()
-    device_2.wpantund_process = wpantund_process_2
+        device_2_id = random.randint(11, 20)
+        device_2_parid = random.getrandbits(16)
+        device_2 = MockThreadDevBoard("device_2", device_2_id)
+        wpantund_process_2 = MockWpantundProcess()
+        device_2.wpantund_process = wpantund_process_2
 
-    manager.add_node(device_1)
-    manager.add_node(device_2)
+        manager.add_node(device_1)
+        manager.add_node(device_2)
 
-    manager.subscribe_to_node(device_1)
-    manager.subscribe_to_node(device_2)
+        manager.subscribe_to_node(device_1)
+        manager.subscribe_to_node(device_2)
 
-    wpantund_process_1.emit_status(f"parid={device_1_parid:08x}")
-    wpantund_process_2.emit_status(f"parid={device_2_parid:08x}")
-    ns.go(0.1)
+        wpantund_process_1.emit_status(f"parid={device_1_parid:08x}")
+        wpantund_process_2.emit_status(f"parid={device_2_parid:08x}")
+        ns.go(0.1)
 
-    partitions_info = ns.partitions()
-    self.assertEqual(len(partitions_info), 2)
-    self.assertEqual(len(partitions_info[device_1_parid]), 1)
-    self.assertEqual(len(partitions_info[device_2_parid]), 1)
-    self.assertEqual(partitions_info[device_1_parid][0], device_1.id)
-    self.assertEqual(partitions_info[device_2_parid][0], device_2.id)
+        partitions_info = ns.partitions()
+        self.assertEqual(len(partitions_info), 2)
+        self.assertEqual(len(partitions_info[device_1_parid]), 1)
+        self.assertEqual(len(partitions_info[device_2_parid]), 1)
+        self.assertEqual(partitions_info[device_1_parid][0], device_1.id)
+        self.assertEqual(partitions_info[device_2_parid][0], device_2.id)
 
-    wpantund_process_2.emit_status(f"parid={device_1_parid:08x}")
-    ns.go(0.1)
+        wpantund_process_2.emit_status(f"parid={device_1_parid:08x}")
+        ns.go(0.1)
 
-    partitions_info = ns.partitions()
-    self.assertEqual(len(partitions_info), 1)
-    self.assertEqual(len(partitions_info[device_1_parid]), 2)
-    self.assertTrue(device_1.id in partitions_info[device_1_parid])
-    self.assertTrue(device_2.id in partitions_info[device_1_parid])
+        partitions_info = ns.partitions()
+        self.assertEqual(len(partitions_info), 1)
+        self.assertEqual(len(partitions_info[device_1_parid]), 2)
+        self.assertTrue(device_1.id in partitions_info[device_1_parid])
+        self.assertTrue(device_2.id in partitions_info[device_1_parid])
 
-    wpantund_process_2.emit_status(f"parid={device_2_parid:08x}")
-    ns.go(0.1)
+        wpantund_process_2.emit_status(f"parid={device_2_parid:08x}")
+        ns.go(0.1)
 
-    partitions_info = ns.partitions()
-    self.assertEqual(len(partitions_info), 2)
-    self.assertEqual(len(partitions_info[device_1_parid]), 1)
-    self.assertEqual(len(partitions_info[device_2_parid]), 1)
-    self.assertEqual(partitions_info[device_1_parid][0], device_1.id)
-    self.assertEqual(partitions_info[device_2_parid][0], device_2.id)
+        partitions_info = ns.partitions()
+        self.assertEqual(len(partitions_info), 2)
+        self.assertEqual(len(partitions_info[device_1_parid]), 1)
+        self.assertEqual(len(partitions_info[device_2_parid]), 1)
+        self.assertEqual(partitions_info[device_1_parid][0], device_1.id)
+        self.assertEqual(partitions_info[device_2_parid][0], device_2.id)
 
-  # TODO: Add child & router table tests after adding query support to OTNS CLI
+    # TODO: Add child & router table tests after adding query support to OTNS CLI
+
 
 if __name__ == "__main__":
-  unittest.main()
+    unittest.main()

--- a/silk/unit_tests/testcase.py
+++ b/silk/unit_tests/testcase.py
@@ -18,11 +18,13 @@ import unittest
 
 LOG_LINE_FORMAT = "[%(asctime)s] [%(name)s] [%(levelname)s] %(message)s"
 
+
 class SilkTestCase(unittest.TestCase):
-  """Silk unit test base case.
-  """
-  @classmethod
-  def setUpClass(cls) -> None:
-    tracemalloc.start()
-    logging.basicConfig(level=logging.DEBUG, format=LOG_LINE_FORMAT)
-    cls.logger = logging.Logger(cls.__name__)
+    """Silk unit test base case.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        tracemalloc.start()
+        logging.basicConfig(level=logging.DEBUG, format=LOG_LINE_FORMAT)
+        cls.logger = logging.Logger(cls.__name__)

--- a/silk/utils/decorator.py
+++ b/silk/utils/decorator.py
@@ -12,16 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import object
-import functools
 import collections
+import functools
 
 
 class memoized(object):
-    '''Decorator. Caches a function's return value each time it is called.
-    If called later with the same arguments, the cached value is returned
-    (not reevaluated).
-    '''
+    """Decorator. Caches a function's return value each time it is called.
+    If called later with the same arguments, the cached value is returned (not reevaluated).
+    """
+
     def __init__(self, func):
         self.func = func
         self.cache = {}
@@ -39,22 +38,22 @@ class memoized(object):
             return value
 
     def __repr__(self):
-        '''Return the function's docstring.'''
+        """Return the function"s docstring."""
         return self.func.__doc__
 
     def __get__(self, obj, objtype):
-        '''Support instance methods.'''
+        """Support instance methods."""
         return functools.partial(self.__call__, obj)
 
 
 def ignore_attribute_error(func):
+    """Decorator function that ignores AttributeError.
     """
-    Decorator function that ignores AttributeError.
-    """
+
     def wrapped_func(*args, **kwargs):
         try:
             func(*args, **kwargs)
         except AttributeError:
             pass
-    return wrapped_func
 
+    return wrapped_func

--- a/silk/utils/directorypath.py
+++ b/silk/utils/directorypath.py
@@ -11,11 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Directory path utility.
+"""
 
-from builtins import object
-import os
 import inspect
+import os
 import time
+
 WAIT_TIME = 5
 
 
@@ -27,10 +29,10 @@ class DirectoryPath(object):
         timeout = time.time() + WAIT_TIME
         while True:
             if time.time() > timeout:
-                raise RuntimeError("folder_name {} not found".format(folder_name))
-            if file_abs_path.split('/')[-1] != folder_name:
+                raise RuntimeError(f"folder_name {folder_name} not found")
+            if file_abs_path.split("/")[-1] != folder_name:
                 file_abs_path = os.path.dirname(file_abs_path)
                 time.sleep(1)
             else:
-                dir_path = file_abs_path + '/' + path + '/'
+                dir_path = file_abs_path + "/" + path + "/"
                 return dir_path

--- a/silk/utils/jsonfile.py
+++ b/silk/utils/jsonfile.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 # Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,11 +12,10 @@ from __future__ import print_function
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import object
-import os
 import json
+import os
 
-CONF_PATH = '/opt/openthread_test/'
+CONF_PATH = "/opt/openthread_test/"
 
 
 class JsonFile(object):
@@ -28,7 +26,7 @@ class JsonFile(object):
     @staticmethod
     def load_json_file(file_path):
         try:
-            with open(file_path, 'r') as jfile:
+            with open(file_path, "r") as jfile:
 
                 json_data = jfile.read()
                 json_line = json.loads(json_data)
@@ -45,10 +43,10 @@ class JsonFile(object):
         try:
             json_data = json.dumps(json_line, sort_keys=True, indent=2)
         except Exception:
-            print ("Failed to save json file: %s" % (file_path))
+            print("Failed to save json file: %s" % (file_path))
             return
 
-        with open(file_path, 'w') as jfile:
+        with open(file_path, "w") as jfile:
             jfile.write(json_data)
 
     @staticmethod
@@ -70,4 +68,3 @@ class JsonFile(object):
     def is_json_file_existed(conf_file):
         file_path = JsonFile.get_conf_file(conf_file)
         return os.path.isfile(file_path)
-

--- a/silk/utils/multipleprocess.py
+++ b/silk/utils/multipleprocess.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import object
 import multiprocessing
 import time
 

--- a/silk/utils/process.py
+++ b/silk/utils/process.py
@@ -11,13 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-"""
-this module is used to execute the shell script
+"""This module is used to execute the shell script.
 """
 
-from __future__ import absolute_import, print_function
-from builtins import object
 import os
 import subprocess
 import threading
@@ -39,8 +35,8 @@ class Process(object):
     def process_cmd_asyc_end(self, key_word):
         self.stop_thread.set()
         kill_cmd = "ps -ef | grep " + "'" + key_word + "'"  \
-                  + " | grep -v grep | awk '{print $2}'"         \
-                  + " | xargs kill"
+            + " | grep -v grep | awk '{print $2}'"          \
+            + " | xargs kill"
         print(kill_cmd)
         os.popen(kill_cmd)
 
@@ -54,15 +50,15 @@ class Process(object):
                                         shell=True)
         print(self.process.pid)
 
-        proc_thread = threading.Thread(target=self.read, args=(self.process, ))
+        proc_thread = threading.Thread(target=self.read, args=(self.process,))
         proc_thread.start()
 
     def read(self, process):
         while not self.stop_thread.is_set():
-            output = process.stdout.readline().decode('UTF-8')
+            output = process.stdout.readline().decode("UTF-8")
             # TODO: should add the logic to record the log info here. This will be addressed by issue ID #33
             print(output.strip())
-            if output == '' and self.process.poll() is not None:
+            if output == "" and self.process.poll() is not None:
                 break
 
     def get_process(self):
@@ -70,12 +66,12 @@ class Process(object):
 
     def get_process_result(self):
         self.process_cmd()
-        return self.process.communicate()[0].decode('UTF-8')
+        return self.process.communicate()[0].decode("UTF-8")
 
     def get_process_list(self):
         self.process_cmd()
-        res = self.process.communicate()[0].decode('UTF-8')
-        return res if res is not None else ''
+        res = self.process.communicate()[0].decode("UTF-8")
+        return res if res is not None else ""
 
     def get_process_content(self):
         self.process_cmd()

--- a/silk/utils/process_cleanup.py
+++ b/silk/utils/process_cleanup.py
@@ -15,31 +15,30 @@
 import subprocess
 import logging
 
-LOG_FILE = '/opt/openthread_test/results/ps_cleanup.log'
+LOG_FILE = "/opt/openthread_test/results/ps_cleanup.log"
 
 
-def ps_cleanup(usb_port='ALL', logname=LOG_FILE):
+def ps_cleanup(usb_port="ALL", logname=LOG_FILE):
+    logging.basicConfig(format="%(levelname)s:%(message)s", filename=logname, level=logging.DEBUG)
 
-        logging.basicConfig(format='%(levelname)s:%(message)s', filename=logname, level=logging.DEBUG)
+    logging.info("*" * 30 + "  New logs  " + "*" * 30)
 
-        logging.info('*'*30 + '  New logs  ' + '*'*30)
+    output = subprocess.check_output("ps -ef | grep wpantund", shell=True)
+    logging.info("#" * 10 + "wpantund and ttyACM process info after tearDownClass" + "#" * 10)
+    logging.info(output)
 
-        output = subprocess.check_output('ps -ef | grep wpantund', shell=True)
-        logging.info('#'*10 + 'wpantund and ttyACM process info after tearDownClass'  + '#'*10)
-        logging.info(output)
+    logging.info("#" * 10 + "Kill all wpantund processes if any " + "#" * 10)
+    output_str = output.decode("utf-8")
+    for line in output_str:
+        if "sbin/wpantund" in line and (usb_port.upper() == "ALL" or line.split()[-1] == usb_port):
+            pid = line.split()[1]
+            logging.info(pid)
+            cmd = "sudo kill -9 " + pid
+            logging.info(subprocess.check_output(cmd, shell=True).decode("utf-8"))
 
-        logging.info('#'*10 + 'Kill all wpantund processes if any ' +  '#'*10)
-        output_str = output.decode('utf-8')
-        for line in output_str:
-            if 'sbin/wpantund' in line and (usb_port.upper() == 'ALL' or line.split()[-1] == usb_port):
-                pid = line.split()[1]
-                logging.info(pid)
-                cmd = 'sudo kill -9 ' + pid
-                logging.info(subprocess.check_output(cmd, shell=True).decode('utf-8'))
-
-        output = subprocess.check_output('ps -ef | grep ttyACM', shell=True).decode('utf-8')
-        logging.info(output)
+    output = subprocess.check_output("ps -ef | grep ttyACM", shell=True).decode("utf-8")
+    logging.info(output)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     ps_cleanup(LOG_FILE)

--- a/silk/utils/signal.py
+++ b/silk/utils/signal.py
@@ -11,11 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Implements publisher/subscriber classes for passing messages.
+"""
 
-"""
-Implements publisher/subscriber classes for passing messages.
-"""
-from builtins import object
 import logging
 
 from django.dispatch import Signal
@@ -24,28 +22,24 @@ from silk.utils import decorator
 
 
 class SignalLoggerAdapter(logging.LoggerAdapter):
+    """LoggerAdapter for adding extra logging to signal classes.
     """
-    LoggerAdapter for adding extra logging to signal classes.
-    """
+
     def process(self, msg, kwargs):
         """
-        This will print out not only the standard Lattice logline, but also
-        the subscriber that reported the log event and the source of the line
-        (if available).
+        This will print out not only the standard Lattice logline, but also the subscriber that reported
+        the log event and the source of the line (if available).
         """
-        return "%s%s: %s" % (self.extra['source'], self.extra['classname'], msg), kwargs
+        return "%s%s: %s" % (self.extra["source"], self.extra["classname"], msg), kwargs
 
 
 class SignalLogger(object):
-    """
-    Convenient class for adding logging functionality only if a logger is set
-    in the class.
+    """Convenient class for adding logging functionality only if a logger is set in the class.
     """
 
     @property
     def logger(self):
-        """
-        Returns the SignalLoggerAdapter instance. None if never set.
+        """Returns the SignalLoggerAdapter instance. None if never set.
         """
         try:
             return self._logger
@@ -54,175 +48,150 @@ class SignalLogger(object):
 
     @logger.setter
     def logger(self, value):
-        """
-        Sets the logger by wrapping it with the SignalLoggerAdapter.
+        """Sets the logger by wrapping it with the SignalLoggerAdapter.
         """
         if not isinstance(value, logging.Logger):
             raise TypeError("value must be a Logger type")
 
         try:
-            source = ("%s " % self.sourceName) if self.sourceName else ""
+            source = ("%s " % self.source_name) if self.source_name else ""
         except AttributeError:
             source = ""
 
-        self._logger = SignalLoggerAdapter(value,
-                                           {'source': source,
-                                            'classname': self.__class__.__name__})
+        self._logger = SignalLoggerAdapter(value, {"source": source, "classname": self.__class__.__name__})
 
     @decorator.ignore_attribute_error
     def debug(self, msg, *args, **kwargs):
-        """
-        Log message at DEBUG level.
+        """Log message at DEBUG level.
         """
         self.logger.debug(msg, *args, **kwargs)
 
     @decorator.ignore_attribute_error
     def info(self, msg, *args, **kwargs):
-        """
-        Log message at INFO level.
+        """Log message at INFO level.
         """
         self.logger.info(msg, *args, **kwargs)
 
     @decorator.ignore_attribute_error
     def warn(self, msg, *args, **kwargs):
-        """
-        Alias of warning.
+        """Alias of warning.
         """
         self.warning(msg, *args, **kwargs)
 
     @decorator.ignore_attribute_error
     def warning(self, msg, *args, **kwargs):
-        """
-        Log message at WARN level.
+        """Log message at WARN level.
         """
         self.logger.warning(msg, *args, **kwargs)
 
     @decorator.ignore_attribute_error
     def error(self, msg, *args, **kwargs):
-        """
-        Log message at ERROR level.
+        """Log message at ERROR level.
         """
         self.logger.error(msg, *args, **kwargs)
 
     @decorator.ignore_attribute_error
     def critical(self, msg, *args, **kwargs):
-        """
-        Log message at CRITICAL level.
+        """Log message at CRITICAL level.
         """
         self.logger.critical(msg, *args, **kwargs)
 
     @decorator.ignore_attribute_error
     def fatal(self, msg, *args, **kwargs):
-        """
-        Log message at FATAL level.
+        """Log message at FATAL level.
         """
         self.logger.fatal(msg, *args, **kwargs)
 
     @decorator.ignore_attribute_error
     def exception(self, msg, *args, **kwargs):
-        """
-        Log message as exception.
+        """Log message as exception.
         """
         self.logger.exception(msg, *args, **kwargs)
 
 
 class Publisher(SignalLogger):
-    """
-    Base class for signaling Publisher.
+    """Base class for signaling Publisher.
 
     The base __init__ function setups the signaling object that a Subscriber
     can connect to.
 
     The child class
     """
+
     def __init__(self):
-        """
-        Setups signaling object.
+        """Setups signaling object.
         """
         super(Publisher, self).__init__()
         self._signal = Signal()
 
     def subscribe(self, handle):
-        """
-        Subscribe a handle to this publisher.
+        """Subscribe a handle to this publisher.
         """
         self._signal.connect(handle)
 
     def unsubscribe(self, handle):
-        """
-        Unsubscribe a handle from this publisher.
+        """Unsubscribe a handle from this publisher.
         """
         self._signal.disconnect(handle)
 
     def emit(self, **kwargs):
-        """
-        Emits arguments to the subscribers.
+        """Emits arguments to the subscribers.
         """
         self._signal.send(sender=self, **kwargs)
 
 
 class Subscriber(SignalLogger):
     """
-    Base class for signaling Subscriber.
-    """
-    def __init__(self, publisher=None, sourceName=None):
-        """
-        Creates a new subscriber for parsing logs.
+  Base class for signaling Subscriber.
+  """
 
-        :param publisher:
-            Publisher instance to subscribe to.
-        :type publisher:
-            Publisher
+    def __init__(self, publisher=None, source_name=None):
+        """Creates a new subscriber for parsing logs.
 
-        :param sourceName:
-            the source of the log lines. If provided, the source will be
-            printed with each log.
-        :type sourceName:
-            string
+        Args:
+            publisher (Publisher): Publisher instance to subscribe to.
+            source_name (str): the source of the log lines. If provided, the source will be printed with each log.
         """
         super(Subscriber, self).__init__()
 
         self.publishers = []
-        self.sourceName = sourceName
+        self.source_name = source_name
 
         if publisher:
             self.subscribe(publisher)
 
     def __del__(self):
-        """
-        Automatically unsubscribe from all publishers if the object is deleted.
+        """Automatically unsubscribe from all publishers if the object is deleted.
         """
         self.unsubscribe()
 
     def subscribe(self, publisher):
         """
-        Subscribe to a given publisher.
-        """
+    Subscribe to a given publisher.
+    """
         if not isinstance(publisher, Publisher):
-            raise TypeError("publisher must be a type Publisher but was %s"
-                            % type(publisher))
+            raise TypeError("publisher must be a type Publisher but was %s" % type(publisher))
 
-        publisher.subscribe(self.subscribeHandle)
+        publisher.subscribe(self.subscribe_handle)
         self.publishers.append(publisher)
 
     def unsubscribe(self, publisher=None):
-        """
-        Unsubscribe from the pubisher. If publisher argument is None (default),
-        this function will unsubscribe from all publishers.
+        """Unsubscribe from the pubisher.
+
+        If publisher argument is None (default), this function will unsubscribe from all publishers.
         """
         # Defaulting to an empty list here works around a race condition where
         # this object is destroyed via __del__ before __init__ was called.
-        publishers = getattr(self, 'publishers', [])
+        publishers = getattr(self, "publishers", [])
         if publisher is None:
             for publisher in publishers:
-                publisher.unsubscribe(self.subscribeHandle)
+                publisher.unsubscribe(self.subscribe_handle)
             self.publishers = []
         else:
             if publisher in publishers:
-                publisher.unsubscribe(self.subscribeHandle)
+                publisher.unsubscribe(self.subscribe_handle)
 
-    def subscribeHandle(self, sender, **kwargs):
-        """
-        Handler method that should be overwritten from the publisher.
+    def subscribe_handle(self, sender, **kwargs):
+        """Handler method that should be overwritten from the publisher.
         """
         pass

--- a/silk/utils/subprocess_runner.py
+++ b/silk/utils/subprocess_runner.py
@@ -13,24 +13,22 @@ from __future__ import print_function
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import str
+import re
 import select
 import subprocess
 import threading
 import traceback
-import re
 
 from silk.utils import signal
 
 
 class SubprocessRunner(signal.Publisher, threading.Thread):
-    """
-    a class which runs a command
+    """A class which runs a command.
 
     :param command:
         command to run
-
     """
+
     def __init__(self, command):
         super(SubprocessRunner, self).__init__()
 
@@ -40,7 +38,8 @@ class SubprocessRunner(signal.Publisher, threading.Thread):
         self.daemon = True
 
     def start(self):
-        """ start the subprocessrunner, this does not start process """
+        """Start the subprocessrunner, this does not start process.
+        """
         try:
             super(SubprocessRunner, self).start()
             self.running = True
@@ -49,8 +48,7 @@ class SubprocessRunner(signal.Publisher, threading.Thread):
             print("Error in SubprocessRunner start:", str(e))
 
     def stop(self, timeout=15):
-        """
-        end subprocessrunner
+        """End subprocessrunner.
 
         :param int timeout:
             the seconds to wait before force killing the process
@@ -60,29 +58,28 @@ class SubprocessRunner(signal.Publisher, threading.Thread):
             # try joining for 15 seconds, else let the program tear down
             self.join(timeout)
             if self.is_alive():
-                self.warn('SubprocessRunner join timed out')
+                self.warn("SubprocessRunner join timed out")
                 self.proc.kill()
 
     def run(self):
-        """ start the command """
+        """start the command.
+        """
 
         # Added code to handle wpantund start in RCP mode
-        # sudo /usr/local/sbin/wpantund -o Config:NCP:SocketPath 'system:openthread/output/posix/x86_64-unknown-linux-
-        # gnu/bin/ot-ncp /dev/ttyACM0 115200' -o Config:TUN:InterfaceName wpan0 -o Daemon:SyslogMask "all"
+        # sudo /usr/local/sbin/wpantund -o Config:NCP:SocketPath "system:openthread/output/posix/x86_64-unknown-linux-
+        # gnu/bin/ot-ncp /dev/ttyACM0 115200" -o Config:TUN:InterfaceName wpan0 -o Daemon:SyslogMask "all"
 
-        command = re.findall("(?:\".*?\"|\S)+", self.command)
+        command = re.findall(r"(?:\".*?\"|\S)+", self.command)
 
-        command = ' '.join(e for e in command)
+        command = " ".join(e for e in command)
 
-        self.proc = subprocess.Popen(command, bufsize=0,
-                                     stdout=subprocess.PIPE,
-                                     stderr=subprocess.STDOUT, shell=True)
+        self.proc = subprocess.Popen(command, bufsize=0, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
         try:
             while self.running:
                 for s in select.select([self.proc.stdout], [], [], 1)[0]:
                     line = s.readline().rstrip()
                     if line:
-                        line = line.decode('utf-8')
+                        line = line.decode("utf-8")
                         self.emit(line=line)
         except Exception as e:
             traceback.print_exc()

--- a/silk/version.py
+++ b/silk/version.py
@@ -13,9 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 This module maintains the version number of silk.
 """
 
-__version__ = '1.0.0'
+__version__ = "1.0.0"


### PR DESCRIPTION
This PR prettifies Python code.
- Use `yapf` to auto prettify, using Google style, with the exception of setting column limit to 119 to match OT.
- Added other manual fixes, such as breaking longer lines, modifying constant/function names, and unifying single/double quotes.
- Improved `pylint` score from less than 0 to about 9.5 using Google's lint rc file (Fixed more than 20k warnings, still has about 3k to fix).
- Added lint step, but set it to pass in spite of error for the time being.
- Ran through all 118 Silk test cases to verify that no functionality has been broken.