### PR TITLE
Add default log_info implementation

### DIFF
--- a/silk/device/netns_base.py
+++ b/silk/device/netns_base.py
@@ -190,6 +190,14 @@ class NetnsController(SystemCallManager):
                                                            via_addr, interface_name)
         self.make_netns_call_async(command, "", 1, None)
 
+    def log_info(self, log_line: str):
+        """Default implementation for log_info.
+
+        Args:
+            log_line (str): line to log.
+        """
+        print(log_line)
+
 
 class StandaloneNetworkNamespace(NetnsController, BaseNode):
     """


### PR DESCRIPTION
This commit add default `log_info` implementation for `NetnsController` for static-style usage.