### PR TITLE
Use platform agnostic code to get local IP

### DIFF
--- a/silk/node/fifteen_four_dev_board.py
+++ b/silk/node/fifteen_four_dev_board.py
@@ -16,7 +16,6 @@ from builtins import str
 import logging
 import os
 import re
-import socket
 import time
 import datetime
 import traceback
@@ -38,19 +37,12 @@ from silk.utils.directorypath import DirectoryPath
 from silk.utils.process import Process
 from silk.postprocessing import ip as silk_ip
 from silk.utils.jsonfile import JsonFile
+from silk.utils.network import get_local_ip
 
 
 LOG_PATH = '/opt/openthread_test/results/'
 POSIX_PATH = '/opt/openthread_test/posix'
 RETRY = 3
-
-
-def get_local_ip():
-    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    sock.connect(("8.8.8.8", 80))
-    local_host = sock.getsockname()[0]
-    sock.close()
-    return local_host
 
 
 class WpantundMonitor(signal.Subscriber):

--- a/silk/node/fifteen_four_dev_board.py
+++ b/silk/node/fifteen_four_dev_board.py
@@ -45,9 +45,6 @@ POSIX_PATH = '/opt/openthread_test/posix'
 RETRY = 3
 
 
-IP_INTERFACES = ('eth0', 'eno1', 'wlp0s20f3')
-
-
 def get_local_ip():
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.connect(("8.8.8.8", 80))

--- a/silk/node/fifteen_four_dev_board.py
+++ b/silk/node/fifteen_four_dev_board.py
@@ -16,6 +16,7 @@ from builtins import str
 import logging
 import os
 import re
+import socket
 import time
 import datetime
 import traceback
@@ -48,12 +49,11 @@ IP_INTERFACES = ('eth0', 'eno1', 'wlp0s20f3')
 
 
 def get_local_ip():
-    for ip_interface in IP_INTERFACES:
-        cmd = 'ifconfig ' + ip_interface
-        cmd += ' | grep "inet "'
-        config_data = os.popen(cmd).read()
-        if 'inet' in config_data:
-            return config_data
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.connect(("8.8.8.8", 80))
+    local_host = sock.getsockname()[0]
+    sock.close()
+    return local_host
 
 
 class WpantundMonitor(signal.Subscriber):
@@ -126,7 +126,7 @@ class FifteenFourDevBoardNode(WpantundWpanNode, NetnsController):
         self.wpantund_verbose_debug = wpantund_verbose_debug
         self.thread_mode = 'NCP'
         if not virtual:
-            local_ip = get_local_ip().strip().split()[1]
+            local_ip = get_local_ip()
 
             try:
                 cluster_list = JsonFile.get_json('clusters.conf')['clusters']

--- a/silk/tools/otns_manager.py
+++ b/silk/tools/otns_manager.py
@@ -35,6 +35,7 @@ from silk.node.fifteen_four_dev_board import ThreadDevBoard
 from silk.tools.pb import visualize_grpc_pb2
 from silk.tools.pb import visualize_grpc_pb2_grpc
 from silk.utils import signal
+from silk.utils.network import get_local_ip
 
 DATE_FORMAT = "%Y-%m-%d %H:%M:%S,%f"
 
@@ -799,10 +800,7 @@ class OtnsManager(object):
     self.max_node_count = 0
     self.node_summaries = {}
 
-    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    sock.connect(("8.8.8.8", 80))
-    self.local_host = sock.getsockname()[0]
-    sock.close()
+    self.local_host = get_local_ip()
 
     self.logger = logger
     self.logger.info(

--- a/silk/utils/network.py
+++ b/silk/utils/network.py
@@ -18,14 +18,12 @@ import socket
 
 
 def get_local_ip():
-  sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-  try:
-    # server does not need to be reachable
-    sock.connect(("8.8.8.8", 80))
-    local_host = sock.getsockname()[0]
-  except Exception:
-    # exception raised if interface does not exist
-    local_host = "127.0.0.1"
-  finally:
-    sock.close()
-  return local_host
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        try:
+            # server does not need to be reachable
+            sock.connect(("8.8.8.8", 80))
+            local_host = sock.getsockname()[0]
+        except Exception:
+            # exception raised if interface does not exist
+            local_host = "127.0.0.1"
+    return local_host

--- a/silk/utils/network.py
+++ b/silk/utils/network.py
@@ -1,0 +1,31 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Network utilities.
+"""
+
+import socket
+
+
+def get_local_ip():
+  sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+  try:
+    # server does not need to be reachable
+    sock.connect(("8.8.8.8", 80))
+    local_host = sock.getsockname()[0]
+  except Exception:
+    # exception raised if interface does not exist
+    local_host = "127.0.0.1"
+  finally:
+    sock.close()
+  return local_host


### PR DESCRIPTION
This commit changes `get_local_ip` method to be platform agnostic. Fixes the issue where Debian doesn't have `ifconfig` installed by default, causing this to fail.

P.S. this is the same method used in `OtnsManager.__init__` to get local IP. Can be abstracted away in the future.