### PR TITLE
Allow specifying netns name for StandaloneNetworkNamespace

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,4 +6,4 @@ coverage:
 
     patch:
       default:
-        target: 10%
+        target: 0%

--- a/silk/device/netns_base.py
+++ b/silk/device/netns_base.py
@@ -190,14 +190,6 @@ class NetnsController(SystemCallManager):
                                                            via_addr, interface_name)
         self.make_netns_call_async(command, "", 1, None)
 
-    def log_info(self, log_line: str):
-        """Default implementation for log_info.
-
-        Args:
-            log_line (str): line to log.
-        """
-        print(log_line)
-
 
 class StandaloneNetworkNamespace(NetnsController, BaseNode):
     """
@@ -205,9 +197,9 @@ class StandaloneNetworkNamespace(NetnsController, BaseNode):
     with a development board.
     """
     def __init__(self, netns_name):
-        self.device_path = os.path.join("/dev", netns_name)
+        device_path = os.path.join("/dev", netns_name)
         BaseNode.__init__(self, netns_name)
-        NetnsController.__init__(self)
+        NetnsController.__init__(self, netns_name, device_path)
 
     def tear_down(self):
         self.cleanup_netns()

--- a/silk/node/fifteen_four_dev_board.py
+++ b/silk/node/fifteen_four_dev_board.py
@@ -160,7 +160,7 @@ class FifteenFourDevBoardNode(WpantundWpanNode, NetnsController):
             self.log_info('Device Path: {}'.format(self.device_path))
 
             # Setup netns
-            NetnsController.__init__(self)
+            NetnsController.__init__(self, self.netns, self.device_path)
 
 #################################
 #   Logging functions
@@ -222,7 +222,7 @@ class FifteenFourDevBoardNode(WpantundWpanNode, NetnsController):
             self.logger.critical(e.message)
             self.logger.debug('Cannot start wpantund on {}'.format(self.netns))
 
-        NetnsController.__init__(self)
+        NetnsController.__init__(self, self.netns, self.device_path)
 
         self.thread_interface = self.netns
         self.legacy_interface = self.netns + "-L"


### PR DESCRIPTION
This commit allows specifying `netns` name for `StandaloneNetworkNamespace` for static style use.