### PR TITLE
Port Toranj Traffic Test

### DIFF
--- a/silk/device/netns_base.py
+++ b/silk/device/netns_base.py
@@ -129,14 +129,14 @@ class NetnsController(SystemCallManager):
         command = self.construct_netns_command(command)
         return self._make_system_call("netns-exec", command, timeout)
 
-    def make_netns_call_async(self, command, expect, timeout, field=None):
+    def make_netns_call_async(self, command, expect, timeout, field=None, exact_match: bool = False):
         """
         Take a standard system call (eg: ifconfig, ping, etc.).
         Format the command so that it will be called in this network namespace.
         Make the system call with a timeout.
         """
         command = self.construct_netns_command(command)
-        return self.make_system_call_async("netns-exec", command, expect, timeout, field)
+        return self.make_system_call_async("netns-exec", command, expect, timeout, field, exact_match)
 
     def link_set(self, interface_name, virtual_eth_peer):
         """

--- a/silk/device/system_call_manager.py
+++ b/silk/device/system_call_manager.py
@@ -183,9 +183,9 @@ class SystemCallManager(object):
             while True:
                 try:
                     new_char = proc.stdout.read(1)
-                    this_stdout += new_char.decode("utf-8")
                     if not new_char:
                         break
+                    this_stdout += new_char.decode("utf-8")
                 except Exception as err:
                     print("Exception: {}".format(err))
                     break

--- a/silk/device/system_call_manager.py
+++ b/silk/device/system_call_manager.py
@@ -29,7 +29,7 @@ class MessageSystemCallItem(message_item.MessageItemBase):
     """Class to encapsulate a system call into the message queue.
     """
 
-    def __init__(self, action, cmd, expect, timeout, field, refresh=0):
+    def __init__(self, action, cmd, expect, timeout, field, refresh=0, exact_match: bool = False):
         super(MessageSystemCallItem, self).__init__()
 
         self.action = action
@@ -38,6 +38,7 @@ class MessageSystemCallItem(message_item.MessageItemBase):
         self.timeout = timeout
         self.field = field
         self.refresh = refresh
+        self.exact_match = exact_match
 
     def log_match_failure(self, response):
         self.parent.log_error("Worker failed to match expected output.")
@@ -61,8 +62,7 @@ class MessageSystemCallItem(message_item.MessageItemBase):
 
     def invoke(self, parent):
         """
-        Consumer thread for serializing and asynchronously handling command
-        inputs and expected returns.
+        Consumer thread for serializing and asynchronously handling command inputs and expected returns.
         Make system calls using the _make_system_call method.
         """
         self.parent = parent
@@ -80,16 +80,26 @@ class MessageSystemCallItem(message_item.MessageItemBase):
             self.log_response_failure()
             return
 
-        match = re.search(self.expect, response)
+        if self.exact_match:
+            response = response.rstrip()
 
-        if match is None:
-            self.log_match_failure(response)
-            return
+            if response != self.expect:
+                self.log_match_failure(response)
+                return
 
-        if type(self.field) is str:
-            self.parent.store_data(match.group(), self.field)
-        elif type(self.field) is list:
-            self.store_groupdict_match(match)
+            if type(self.field) is str:
+                self.parent.store_data(response, self.field)
+        else:
+            match = re.search(self.expect, response)
+
+            if match is None:
+                self.log_match_failure(response)
+                return
+
+            if type(self.field) is str:
+                self.parent.store_data(match.group(), self.field)
+            elif type(self.field) is list:
+                self.store_groupdict_match(match)
 
 
 class SystemCallManager(object):
@@ -101,13 +111,11 @@ class SystemCallManager(object):
         self.__worker_thread.daemon = True
         self.__worker_thread.start()
 
-    def make_system_call_async(self, action, command, expect, timeout, field=None):
-        """
-        Post a command, timeout, and expect value to a queue for the consumer
-        thread.
+    def make_system_call_async(self, action, command, expect, timeout, field=None, exact_match: bool = False):
+        """Post a command, timeout, and expect value to a queue for the consumer thread.
         """
         self.log_info("Enqueuing command \"%s\"" % command)
-        item = MessageSystemCallItem(action, command, expect, timeout, field)
+        item = MessageSystemCallItem(action, command, expect, timeout, field, exact_match)
 
         with self.__event_lock:
             self.set_all_clear(False)
@@ -115,8 +123,7 @@ class SystemCallManager(object):
             self.log_debug("Message enqueued")
 
     def make_function_call_async(self, function, *args):
-        """
-        Enqueue a Python function to be called on the worker thread
+        """Enqueue a Python function to be called on the worker thread.
         """
         self.log_info("Enqueueing function %s with args %s" % (function, args))
         item = message_item.MessageCallableItem(function, args)
@@ -127,8 +134,7 @@ class SystemCallManager(object):
             self.log_debug("Message enqueued")
 
     def _make_system_call(self, action, command, timeout):
-        """
-        Generic method for making a system call with timeout
+        """Generic method for making a system call with timeout.
         """
 
         log_line = "Making system call for %s" % action

--- a/silk/node/wpantund_base.py
+++ b/silk/node/wpantund_base.py
@@ -75,9 +75,9 @@ class WpantundWpanNode(wpan_node.WpanNode):
         self.store_data(None, self.xpanid_label)
         self.store_data(None, "ping_loss")
 
-#################################
-#   base_node functionality
-#################################
+    #################################
+    #   base_node functionality
+    #################################
 
     def set_up(self):
         pass
@@ -100,9 +100,9 @@ class WpantundWpanNode(wpan_node.WpanNode):
 
         return self.getprop("NCPVersion")
 
-#################################
-#   wpan_MAC Filter functionality
-#################################
+    #################################
+    #   wpan_MAC Filter functionality
+    #################################
 
     def whitelist_node(self, node):
         """Adds a given node (of type `Node`) to the whitelist of `self` and enables whitelisting on `self`.
@@ -115,9 +115,9 @@ class WpantundWpanNode(wpan_node.WpanNode):
         """
         self.remove(wpan.WPAN_MAC_WHITELIST_ENTRIES, node.get(wpan.WPAN_EXT_ADDRESS)[1:-1])
 
-#################################
-#   wpan_node functionality
-#################################
+    #################################
+    #   wpan_node functionality
+    #################################
 
     def form(self, network, role, xpanid=None, panid=None):
         """
@@ -320,9 +320,9 @@ class WpantundWpanNode(wpan_node.WpanNode):
             "remove-route " + route_prefix + (" -l {}".format(prefix_len) if prefix_len is not None else "") +
             (" -p {}".format(priority) if priority is not None else ""))
 
-#################################
-#   Calls into wpanctl for commissioning process in commissioner-joiner model
-#################################
+    #################################
+    #   Calls into wpanctl for commissioning process in commissioner-joiner model
+    #################################
 
     def commissioner_start(self):
         self.wpanctl_async("commissioner start", "commissioner start", "Commissioner started", 20)
@@ -337,9 +337,9 @@ class WpantundWpanNode(wpan_node.WpanNode):
     def joiner_attach(self):
         return self.wpanctl("joiner-attach", "joiner --attach", 20)
 
-#################################
-#   Calls into wpanctl for querying commissioning data
-#################################
+    #################################
+    #   Calls into wpanctl for querying commissioning data
+    #################################
 
     def setprop(self, key, value, data=False):
         """
@@ -385,7 +385,7 @@ class WpantundWpanNode(wpan_node.WpanNode):
     def ping6(self, ipv6_target, num_pings, payload_size=8, interface=None):
         """Perform ping6 to ipv6_target.
 
-        Enable ping6_sent and ping6_received functionality as in silabs_topaz2_thread_node.
+        Enable ping6_sent and ping6_received functionality.
 
         Make the ping call and store the % loss. Also store the number of pings sent.
         """
@@ -422,7 +422,7 @@ class WpantundWpanNode(wpan_node.WpanNode):
         command += " %s -c %s -s %s -W 2" % (ipv6_target, num_pings, payload_size)
 
         search_string = r"rtt min/avg/max/mdev = \d+\.\d+/(?P<%s>\d+\.\d+)/\d+\.\d+/\d+\.\d+ ms" \
-            % (self.ping6_round_trip_time_label)
+                % self.ping6_round_trip_time_label
 
         fields = [self.ping6_round_trip_time_label]
 
@@ -432,18 +432,27 @@ class WpantundWpanNode(wpan_node.WpanNode):
     #   UDP functionality
     #################################
 
-    def send_udp_data(self, ipv6_target, port, message):
+    def send_udp_data(self, target, port, message, source=None):
         """Perform netcat command to send UDP message to ipv6_target via port.
-        """
 
-        command = f"echo -n \"{message}\" | nc -u {ipv6_target} {port}"
+        Args:
+            target (str): target address.
+            port (int): target port.
+            message (str): message to send.
+            source (str, optional): source address. Defaults to None.
+        """
+        source_clause = f"-s {source}" if source else ""
+        command = f"nc -6u {source_clause} {target} {port} <<< \"{message}\""
 
         self.make_netns_call(command)
 
     def receive_udp_data(self, port, message):
         """Perform netcat command to receive expected UDP message from port.
-        """
 
-        command = f"nc -u -l {port}"
+        Args:
+            port (int): target listening port.
+            message (str): message to expect.
+        """
+        command = f"nc -6lu {port}"
 
         self.make_netns_call_async(command, message, timeout=10)

--- a/silk/node/wpantund_base.py
+++ b/silk/node/wpantund_base.py
@@ -29,7 +29,7 @@ class WpantundWpanNode(wpan_node.WpanNode):
     can be ported to control Nordic, SiLabs dev boards, and any other dev board connected to a Linux machine
     with wpantund running in network name spaces and any other device that runs wpantund.
 
-    This base class contains all the necessary hooks for calling into wpanctlto configure the NCP and query its
+    This base class contains all the necessary hooks for calling into wpanctl to configure the NCP and query its
     state information.
 
     Requirements for inheriting classes:
@@ -378,19 +378,16 @@ class WpantundWpanNode(wpan_node.WpanNode):
         return self.wpanctl(action, action + " " + prop_name + " " + ("-d " if binary_data else "") + "-v " + value,
                             2)  # use -v to handle values starting with `-`.
 
-
-#################################
-#   Ping functionality
-#################################
+    #################################
+    #   Ping functionality
+    #################################
 
     def ping6(self, ipv6_target, num_pings, payload_size=8, interface=None):
         """Perform ping6 to ipv6_target.
 
-        Enable ping6_sent and ping6_received functionality as in
-        silabs_topaz2_thread_node.
+        Enable ping6_sent and ping6_received functionality as in silabs_topaz2_thread_node.
 
-        Make the ping call and store the % loss.
-        Also store the number of pings sent.
+        Make the ping call and store the % loss. Also store the number of pings sent.
         """
 
         command = "ping6"
@@ -430,3 +427,23 @@ class WpantundWpanNode(wpan_node.WpanNode):
         fields = [self.ping6_round_trip_time_label]
 
         self.make_netns_call_async(command, search_string, num_pings * 2 + 1, field=fields)
+
+    #################################
+    #   UDP functionality
+    #################################
+
+    def send_udp_data(self, ipv6_target, port, message):
+        """Perform netcat command to send UDP message to ipv6_target via port.
+        """
+
+        command = f"echo -n \"{message}\" | nc -u {ipv6_target} {port}"
+
+        self.make_netns_call(command)
+
+    def receive_udp_data(self, port, message):
+        """Perform netcat command to receive expected UDP message from port.
+        """
+
+        command = f"nc -u -l {port}"
+
+        self.make_netns_call_async(command, message, timeout=10)

--- a/silk/node/wpantund_base.py
+++ b/silk/node/wpantund_base.py
@@ -457,4 +457,4 @@ class WpantundWpanNode(wpan_node.WpanNode):
         """
         command = f"nc -6lu {port}"
 
-        self.make_netns_call_async(command, message, timeout=timeout)
+        self.make_netns_call_async(command, message, timeout=timeout, exact_match=True)

--- a/silk/node/wpantund_base.py
+++ b/silk/node/wpantund_base.py
@@ -432,7 +432,7 @@ class WpantundWpanNode(wpan_node.WpanNode):
     #   UDP functionality
     #################################
 
-    def send_udp_data(self, target, port, message, source=None):
+    def send_udp_data(self, target: str, port: int, message: str, source: str = None, hop_limit: int = 64):
         """Perform netcat command to send UDP message to ipv6_target via port.
 
         Args:
@@ -440,19 +440,21 @@ class WpantundWpanNode(wpan_node.WpanNode):
             port (int): target port.
             message (str): message to send.
             source (str, optional): source address. Defaults to None.
+            hop_limit (int, optional): packet hop limit. Defaults to 64.
         """
         source_clause = f"-s {source}" if source else ""
-        command = f"nc -6u {source_clause} {target} {port} <<< \"{message}\""
+        command = f"nc -6u -M {hop_limit} {source_clause} {target} {port} <<< \"{message}\""
 
         self.make_netns_call(command)
 
-    def receive_udp_data(self, port, message):
+    def receive_udp_data(self, port: int, message: str, timeout: int = 10):
         """Perform netcat command to receive expected UDP message from port.
 
         Args:
             port (int): target listening port.
             message (str): message to expect.
+            timeout (int, optional): timeout for waiting for the async call output. Defaults to 10.
         """
         command = f"nc -6lu {port}"
 
-        self.make_netns_call_async(command, message, timeout=10)
+        self.make_netns_call_async(command, message, timeout=timeout)

--- a/silk/tests/openthread/ot_test_traffic_router_end_device.py
+++ b/silk/tests/openthread/ot_test_traffic_router_end_device.py
@@ -117,7 +117,7 @@ class TestTrafficRouterEndDevice(testcase.TestCase):
             (self.end_device, self.router, AddressType.MLA, AddressType.MLA)
         ]
 
-        timeout = 10
+        timeout = 5
         for i, (src, dst, src_type, dst_type) in enumerate(addresses):
             port = random.randint(10000 + i * 100, 10099 + i * 100)
             message = random_string(10)
@@ -126,7 +126,7 @@ class TestTrafficRouterEndDevice(testcase.TestCase):
             dst_address = dst.ip6_lla if dst_type == AddressType.LLA else dst.ip6_mla
 
             dst.receive_udp_data(port, message, timeout)
-            for _ in range(3):
+            for _ in range(2):
                 src.send_udp_data(dst_address, port, message, src_address)
 
             time.sleep(timeout)

--- a/silk/tests/openthread/ot_test_traffic_router_end_device.py
+++ b/silk/tests/openthread/ot_test_traffic_router_end_device.py
@@ -117,7 +117,7 @@ class TestTrafficRouterEndDevice(testcase.TestCase):
             (self.end_device, self.router, AddressType.MLA, AddressType.MLA)
         ]
 
-        timeout = 5
+        timeout = 10
         for i, (src, dst, src_type, dst_type) in enumerate(addresses):
             port = random.randint(10000 + i * 100, 10099 + i * 100)
             message = random_string(10)
@@ -126,7 +126,8 @@ class TestTrafficRouterEndDevice(testcase.TestCase):
             dst_address = dst.ip6_lla if dst_type == AddressType.LLA else dst.ip6_mla
 
             dst.receive_udp_data(port, message, timeout)
-            src.send_udp_data(dst_address, port, message, src_address)
+            for _ in range(3):
+                src.send_udp_data(dst_address, port, message, src_address)
 
             time.sleep(timeout)
 

--- a/silk/tests/openthread/ot_test_traffic_router_end_device.py
+++ b/silk/tests/openthread/ot_test_traffic_router_end_device.py
@@ -1,0 +1,115 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test traffic between router and end-device (link-local and mesh-local IPv6 addresses).
+"""
+
+import random
+import unittest
+
+from silk.config import wpan_constants as wpan
+from silk.node.wpan_node import WpanCredentials
+from silk.utils import process_cleanup
+import silk.hw.hw_resource as hwr
+import silk.node.fifteen_four_dev_board as ffdb
+import silk.tests.testcase as testcase
+
+hwr.global_instance()
+
+
+class TestTrafficRouterEndDevice(testcase.TestCase):
+    """Test traffic between a router and an end device in a two node network.
+    """
+
+    @classmethod
+    def hardware_select(cls: 'TestTrafficRouterEndDevice'):
+        cls.router = ffdb.ThreadDevBoard()
+        cls.end_device = ffdb.ThreadDevBoard()
+
+    @classmethod
+    @testcase.setup_class_decorator
+    def setUpClass(cls: 'TestTrafficRouterEndDevice'):
+        # Check and clean up wpantund process if any left over
+        process_cleanup.ps_cleanup()
+
+        cls.hardware_select()
+
+        cls.add_test_device(cls.router)
+        cls.add_test_device(cls.end_device)
+
+        for device in cls.device_list:
+            device.set_logger(cls.logger)
+            device.set_up()
+
+        cls.network_data = WpanCredentials(network_name="SILK-{0:04X}".format(random.randint(0, 0xffff)),
+                                           psk="00112233445566778899aabbccdd{0:04x}".format(random.randint(0, 0xffff)),
+                                           channel=random.randint(11, 25),
+                                           fabric_id="{0:06x}dead".format(random.randint(0, 0xffffff)))
+
+        cls.thread_sniffer_init(cls.network_data.channel)
+
+    @classmethod
+    @testcase.teardown_class_decorator
+    def tearDownClass(cls: 'TestTrafficRouterEndDevice'):
+        for device in cls.device_list:
+            device.tear_down()
+
+    @testcase.setup_decorator
+    def setUp(self):
+        pass
+
+    @testcase.teardown_decorator
+    def tearDown(self):
+        pass
+
+    @testcase.test_method_decorator
+    def test01_Pairing(self):
+        # whitelisting between leader and end device
+        self.end_device.whitelist_node(self.router)
+        self.router.whitelist_node(self.end_device)
+
+        self.router.form(self.network_data, "router")
+        self.router.permit_join(60)
+        self.wait_for_completion(self.device_list)
+
+        self.logger.info(self.router.ip6_lla)
+        self.logger.info(self.router.ip6_thread_ula)
+
+        self.network_data.xpanid = self.router.xpanid
+        self.network_data.panid = self.router.panid
+
+        self.end_device.join(self.network_data, "end-node")
+        self.wait_for_completion(self.device_list)
+
+    @testcase.test_method_decorator
+    def test02_NCP_State(self):
+        self.assertEqual(self.router.getprop(wpan.WPAN_STATE), wpan.STATE_ASSOCIATED)
+        self.assertEqual(self.router.getprop(wpan.WPAN_NAME), self.end_device.getprop(wpan.WPAN_NAME))
+        self.assertEqual(self.router.xpanid, self.end_device.xpanid)
+        self.assertEqual(self.router.panid, self.end_device.panid)
+
+    @testcase.test_method_decorator
+    def test03_Transmit_Receive(self):
+        port = random.randint(10020, 12000)
+        message = "Hi there"
+        for dst in [self.end_device.ip6_lla, self.end_device.ip6_mla]:
+            self.end_device.receive_udp_data(port, message)
+            self.router.send_udp_data(dst, port, message)
+
+        for dst in [self.router.ip6_lla, self.router.ip6_mla]:
+            self.router.receive_udp_data(port, message)
+            self.end_device.send_udp_data(dst, port, message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/silk/tests/openthread/ot_test_traffic_router_end_device.py
+++ b/silk/tests/openthread/ot_test_traffic_router_end_device.py
@@ -117,14 +117,18 @@ class TestTrafficRouterEndDevice(testcase.TestCase):
             (self.end_device, self.router, AddressType.MLA, AddressType.MLA)
         ]
 
+        timeout = 5
         for i, (src, dst, src_type, dst_type) in enumerate(addresses):
             port = random.randint(10000 + i * 100, 10099 + i * 100)
             message = random_string(10)
+
             src_address = f"{src.ip6_lla}%{src.netns}" if src_type == AddressType.LLA else None
             dst_address = dst.ip6_lla if dst_type == AddressType.LLA else dst.ip6_mla
-            dst.receive_udp_data(port, message)
+
+            dst.receive_udp_data(port, message, timeout)
             src.send_udp_data(dst_address, port, message, src_address)
-            time.sleep(5)
+
+            time.sleep(timeout)
 
 
 if __name__ == "__main__":

--- a/silk/tests/openthread/ot_test_traffic_router_end_device.py
+++ b/silk/tests/openthread/ot_test_traffic_router_end_device.py
@@ -118,6 +118,7 @@ class TestTrafficRouterEndDevice(testcase.TestCase):
         ]
 
         timeout = 5
+        delay = 1
         for i, (src, dst, src_type, dst_type) in enumerate(addresses):
             port = random.randint(10000 + i * 100, 10099 + i * 100)
             message = random_string(10)
@@ -126,10 +127,10 @@ class TestTrafficRouterEndDevice(testcase.TestCase):
             dst_address = dst.ip6_lla if dst_type == AddressType.LLA else dst.ip6_mla
 
             dst.receive_udp_data(port, message, timeout)
-            for _ in range(2):
-                src.send_udp_data(dst_address, port, message, src_address)
+            time.sleep(delay)
+            src.send_udp_data(dst_address, port, message, src_address)
 
-            time.sleep(timeout)
+            time.sleep(timeout - delay)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This commit ports Toranj [`test-006-traffic-router-end-device.py`](https://github.com/openthread/openthread/blob/master/tests/toranj/test-006-traffic-router-end-device.py) to Silk.

Note: MLA to LLA does not work with real devices, it seems.

Fixes #61 which was found in `system_call_manager.py`.
Fixes #62 witch exact async call response matching.