### PR TITLE
fix off-mesh-routes parsing issue

### DIFF
--- a/silk/tests/openthread/ot_test_off_mesh_route_traffic.py
+++ b/silk/tests/openthread/ot_test_off_mesh_route_traffic.py
@@ -185,16 +185,13 @@ class TestOffMeshRouteTraffic(testcase.TestCase):
             # its WPAN_THREAD_OFF_MESH_ROUTES list (one time as part of network-wide
             # network data and again as part of the local network data). Note that
             # `r1 and `r2` each add a route, while `sed2` does not.
-            r1_routes = self.r1.wpanctl("get", "get " + wpan.WPAN_THREAD_OFF_MESH_ROUTES, 2)
-            r1_routes = wpan_table_parser.parse_list(r1_routes)
+            r1_routes = wpan_table_parser.parse_list(self.r1.get(wpan.WPAN_THREAD_OFF_MESH_ROUTES))
             self.assertEqual(len(r1_routes), NUM_ROUTES + NUM_ROUTES_LOCAL)
 
-            r2_routes = self.r2.wpanctl("get", "get " + wpan.WPAN_THREAD_OFF_MESH_ROUTES, 2)
-            r2_routes = wpan_table_parser.parse_list(r2_routes)
+            r2_routes = wpan_table_parser.parse_list(self.r2.get(wpan.WPAN_THREAD_OFF_MESH_ROUTES))
             self.assertEqual(len(r2_routes), NUM_ROUTES + NUM_ROUTES_LOCAL)
 
-            sed2_routes = self.sed2.wpanctl("get", "get " + wpan.WPAN_THREAD_OFF_MESH_ROUTES, 2)
-            sed2_routes = wpan_table_parser.parse_list(sed2_routes)
+            sed2_routes = wpan_table_parser.parse_list(self.sed2.get(wpan.WPAN_THREAD_OFF_MESH_ROUTES))
             self.assertEqual(len(sed2_routes), NUM_ROUTES)
 
         verify_within(check_off_mesh_routes, WAIT_TIME)

--- a/silk/tools/wpan_table_parser.py
+++ b/silk/tools/wpan_table_parser.py
@@ -446,8 +446,7 @@ def parse_list(list_string):
     # For each line, skip the first two characters (which are `\t"`) and last character (`"`), then split the string
     # using whitespace as separator. The first entry is the IPv6 address.
     #
-    # return [line[2:-1].split()[0] for line in list_string.split("\n")[1:-1]]
-    return [line[2:-1].split()[0] for line in list_string.split("\n")[1:-2]]
+    return [line[2:-1].split()[0] for line in list_string.split("\n")[1:-1]]
 
 
 class OnMeshPrefix(object):


### PR DESCRIPTION
The issue with parsing was seen when routes were received using wpanctl command in following fashion:
r1_routes = self.r1.wpanctl("get", "get " + wpan.WPAN_THREAD_OFF_MESH_ROUTES, 2)
            r1_routes = wpan_table_parser.parse_list(r1_routes)

Following direct method did not gave any index parsing error and initial parse_list method worked.
------------------------------------------------------------------------
r1_routes = wpan_table_parser.parse_list(self.r1.get(wpan.WPAN_THREAD_OFF_MESH_ROUTES))

Also modified parse_list was affecting test multicast_address so fixed and reverted it to original form.