### PR TITLE
Use respectful terms

### DIFF
--- a/.lintrc
+++ b/.lintrc
@@ -5,13 +5,13 @@
 # Its canonical open-source location is:
 #   https://google.github.io/styleguide/pylintrc
 
-[MASTER]
+[MAIN]
 
-# Add files or directories to the blacklist. They should be base names, not
+# Add files or directories to the denylist. They should be base names, not
 # paths.
 ignore=third_party
 
-# Add files or directories matching the regex patterns to the blacklist. The
+# Add files or directories matching the regex patterns to the denylist. The
 # regex matches against base names, not paths.
 ignore-patterns=.*grpc_pb2
 
@@ -28,12 +28,6 @@ jobs=4
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no
-
-# A comma-separated list of package or module names from where C extensions may
-# be loaded. Extensions are loading into the active Python interpreter and may
-# run arbitrary code
-extension-pkg-whitelist=
-
 
 [MESSAGES CONTROL]
 

--- a/silk/device/netns_base.py
+++ b/silk/device/netns_base.py
@@ -97,16 +97,16 @@ class NetnsController(SystemCallManager):
         return output.split("\n")
 
     def netns_killall(self):
-        """Kill all PIDs in this netns.
+        """Stop all PIDs in this netns.
         """
-        self.log_info("Killing all processes in %s" % self.device_path)
+        self.log_info("Stopping all processes in %s" % self.device_path)
         for pid in self.netns_pids():
             if len(pid.strip()) > 0:
                 self.make_netns_call("kill -SIGINT %s" % pid)
 
     def cleanup_netns(self):
         """
-        Kill all PIDs running in the netns.
+        Stop all PIDs running in the netns.
         Delete the netns.
         """
         self.log_info("Cleaning up network namespace for %s" % self.device_path)

--- a/silk/node/fifteen_four_dev_board.py
+++ b/silk/node/fifteen_four_dev_board.py
@@ -220,8 +220,8 @@ class FifteenFourDevBoardNode(WpantundWpanNode, NetnsController):
 
     def tear_down(self):
         """
-        Kill wpantund in this network namespace.
-        Kill all PIDs running in this network namespace.
+        Stop wpantund in this network namespace.
+        Stop all PIDs running in this network namespace.
         Free the hardware device resource.
         """
         if self.virtual_link_peer is not None:
@@ -340,7 +340,7 @@ class FifteenFourDevBoardNode(WpantundWpanNode, NetnsController):
 
     def __stop_wpantund(self):
         """
-        Kill wpantund inside the network namespace.
+        Stop wpantund inside the network namespace.
         """
         self.log_info("Stopping wpantund")
 

--- a/silk/shell/nrfjprog.sh
+++ b/silk/shell/nrfjprog.sh
@@ -129,7 +129,7 @@ elif [ "$1" = "--rtt" ]; then
     echo -e "\n${STATUS_COLOR}Connecting to RTT Server...${RESET}"
     #telnet localhost 19021
     JLinkRTTClient
-    echo -e "\n${STATUS_COLOR}Killing RTT server ($JLINK_PID)...${RESET}"
+    echo -e "\n${STATUS_COLOR}Stopping RTT server ($JLINK_PID)...${RESET}"
     kill $JLINK_PID
 elif [ "$1" = "--gdbserver" ]; then
     $JLINKGDBSERVER -port $GDB_PORT

--- a/silk/unit_tests/fixture/child_table_log.txt
+++ b/silk/unit_tests/fixture/child_table_log.txt
@@ -3114,7 +3114,7 @@ output: "Done"
 [2020-08-27 16:09:11,941] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 2, resp: output: "Done"
 [2020-08-27 16:09:11,942] [silk.otnsManager] [DEBUG] Updating nodes layout
 [2020-08-27 16:09:11,942] [silk.Dev-9119] [INFO] Cleaning up network namespace for /dev/ttyACM8
-[2020-08-27 16:09:11,943] [silk.Dev-9119] [INFO] Killing all processes in /dev/ttyACM8
+[2020-08-27 16:09:11,943] [silk.Dev-9119] [INFO] Stopping all processes in /dev/ttyACM8
 [2020-08-27 16:09:11,943] [silk.Dev-9119] [INFO] Getting PIDs for network namespace for /dev/ttyACM8
 [2020-08-27 16:09:11,943] [silk.Dev-9119] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:09:11,944] [silk.Dev-9119] [DEBUG] sudo ip netns pids ttyACM8
@@ -3474,7 +3474,7 @@ output: "Done"
 [2020-08-27 16:09:26,010] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 3, resp: output: "Done"
 [2020-08-27 16:09:26,011] [silk.otnsManager] [DEBUG] Updating nodes layout
 [2020-08-27 16:09:26,011] [silk.Dev-4456] [INFO] Cleaning up network namespace for /dev/ttyACM1
-[2020-08-27 16:09:26,011] [silk.Dev-4456] [INFO] Killing all processes in /dev/ttyACM1
+[2020-08-27 16:09:26,011] [silk.Dev-4456] [INFO] Stopping all processes in /dev/ttyACM1
 [2020-08-27 16:09:26,011] [silk.Dev-4456] [INFO] Getting PIDs for network namespace for /dev/ttyACM1
 [2020-08-27 16:09:26,011] [silk.Dev-4456] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:09:26,012] [silk.Dev-4456] [DEBUG] sudo ip netns pids ttyACM1
@@ -3671,7 +3671,7 @@ output: "Done"
 [2020-08-27 16:09:40,075] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 4, resp: output: "Done"
 [2020-08-27 16:09:40,076] [silk.otnsManager] [DEBUG] Updating nodes layout
 [2020-08-27 16:09:40,077] [silk.Dev-C179] [INFO] Cleaning up network namespace for /dev/ttyACM3
-[2020-08-27 16:09:40,077] [silk.Dev-C179] [INFO] Killing all processes in /dev/ttyACM3
+[2020-08-27 16:09:40,077] [silk.Dev-C179] [INFO] Stopping all processes in /dev/ttyACM3
 [2020-08-27 16:09:40,078] [silk.Dev-C179] [INFO] Getting PIDs for network namespace for /dev/ttyACM3
 [2020-08-27 16:09:40,078] [silk.Dev-C179] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:09:40,078] [silk.Dev-C179] [DEBUG] sudo ip netns pids ttyACM3
@@ -3781,7 +3781,7 @@ output: "Done"
 [2020-08-27 16:09:54,075] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 5, resp: output: "Done"
 [2020-08-27 16:09:54,076] [silk.otnsManager] [DEBUG] Updating nodes layout
 [2020-08-27 16:09:54,076] [silk.Dev-BB23] [INFO] Cleaning up network namespace for /dev/ttyACM7
-[2020-08-27 16:09:54,077] [silk.Dev-BB23] [INFO] Killing all processes in /dev/ttyACM7
+[2020-08-27 16:09:54,077] [silk.Dev-BB23] [INFO] Stopping all processes in /dev/ttyACM7
 [2020-08-27 16:09:54,077] [silk.Dev-BB23] [INFO] Getting PIDs for network namespace for /dev/ttyACM7
 [2020-08-27 16:09:54,078] [silk.Dev-BB23] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:09:54,078] [silk.Dev-BB23] [DEBUG] sudo ip netns pids ttyACM7
@@ -3851,7 +3851,7 @@ output: "Done"
 [2020-08-27 16:10:08,160] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 6, resp: output: "Done"
 [2020-08-27 16:10:08,161] [silk.otnsManager] [DEBUG] Updating nodes layout
 [2020-08-27 16:10:08,162] [silk.Dev-1560] [INFO] Cleaning up network namespace for /dev/ttyACM4
-[2020-08-27 16:10:08,163] [silk.Dev-1560] [INFO] Killing all processes in /dev/ttyACM4
+[2020-08-27 16:10:08,163] [silk.Dev-1560] [INFO] ing all processes in /dev/ttyACM4
 [2020-08-27 16:10:08,163] [silk.Dev-1560] [INFO] Getting PIDs for network namespace for /dev/ttyACM4
 [2020-08-27 16:10:08,164] [silk.Dev-1560] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:10:08,164] [silk.Dev-1560] [DEBUG] sudo ip netns pids ttyACM4
@@ -3901,7 +3901,7 @@ output: "Done"
 [2020-08-27 16:10:22,618] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 7, resp: output: "Done"
 [2020-08-27 16:10:22,619] [silk.otnsManager] [DEBUG] Updating nodes layout
 [2020-08-27 16:10:22,620] [silk.Dev-6521] [INFO] Cleaning up network namespace for /dev/ttyACM2
-[2020-08-27 16:10:22,620] [silk.Dev-6521] [INFO] Killing all processes in /dev/ttyACM2
+[2020-08-27 16:10:22,620] [silk.Dev-6521] [INFO] Stopping all processes in /dev/ttyACM2
 [2020-08-27 16:10:22,621] [silk.Dev-6521] [INFO] Getting PIDs for network namespace for /dev/ttyACM2
 [2020-08-27 16:10:22,621] [silk.Dev-6521] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:10:22,622] [silk.Dev-6521] [DEBUG] sudo ip netns pids ttyACM2
@@ -3951,7 +3951,7 @@ output: "Done"
 [2020-08-27 16:10:36,629] [silk.otnsManager.gRPCClient] [INFO] Sending cmd: del 8
 [2020-08-27 16:10:36,636] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 8, resp: output: "Done"
 [2020-08-27 16:10:36,636] [silk.Dev-4F76] [INFO] Cleaning up network namespace for /dev/ttyACM0
-[2020-08-27 16:10:36,637] [silk.Dev-4F76] [INFO] Killing all processes in /dev/ttyACM0
+[2020-08-27 16:10:36,637] [silk.Dev-4F76] [INFO] Stopping all processes in /dev/ttyACM0
 [2020-08-27 16:10:36,637] [silk.Dev-4F76] [INFO] Getting PIDs for network namespace for /dev/ttyACM0
 [2020-08-27 16:10:36,637] [silk.Dev-4F76] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:10:36,638] [silk.Dev-4F76] [DEBUG] sudo ip netns pids ttyACM0

--- a/silk/unit_tests/fixture/form_network_log.txt
+++ b/silk/unit_tests/fixture/form_network_log.txt
@@ -4802,7 +4802,7 @@ output: "Done"
 [2020-08-27 16:16:48,597] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 2, resp: output: "Done"
 [2020-08-27 16:16:48,598] [silk.otnsManager] [DEBUG] Updating nodes layout
 [2020-08-27 16:16:48,599] [silk.Dev-9119] [INFO] Cleaning up network namespace for /dev/ttyACM8
-[2020-08-27 16:16:48,599] [silk.Dev-9119] [INFO] Killing all processes in /dev/ttyACM8
+[2020-08-27 16:16:48,599] [silk.Dev-9119] [INFO] Stopping all processes in /dev/ttyACM8
 [2020-08-27 16:16:48,600] [silk.Dev-9119] [INFO] Getting PIDs for network namespace for /dev/ttyACM8
 [2020-08-27 16:16:48,600] [silk.Dev-9119] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:16:48,600] [silk.Dev-9119] [DEBUG] sudo ip netns pids ttyACM8
@@ -5008,7 +5008,7 @@ output: "Done"
 [2020-08-27 16:17:02,528] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 3, resp: output: "Done"
 [2020-08-27 16:17:02,529] [silk.otnsManager] [DEBUG] Updating nodes layout
 [2020-08-27 16:17:02,529] [silk.Dev-4456] [INFO] Cleaning up network namespace for /dev/ttyACM1
-[2020-08-27 16:17:02,530] [silk.Dev-4456] [INFO] Killing all processes in /dev/ttyACM1
+[2020-08-27 16:17:02,530] [silk.Dev-4456] [INFO] Stopping all processes in /dev/ttyACM1
 [2020-08-27 16:17:02,530] [silk.Dev-4456] [INFO] Getting PIDs for network namespace for /dev/ttyACM1
 [2020-08-27 16:17:02,530] [silk.Dev-4456] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:17:02,530] [silk.Dev-4456] [DEBUG] sudo ip netns pids ttyACM1
@@ -5145,7 +5145,7 @@ output: "Done"
 [2020-08-27 16:17:16,460] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 4, resp: output: "Done"
 [2020-08-27 16:17:16,461] [silk.otnsManager] [DEBUG] Updating nodes layout
 [2020-08-27 16:17:16,462] [silk.Dev-C179] [INFO] Cleaning up network namespace for /dev/ttyACM3
-[2020-08-27 16:17:16,462] [silk.Dev-C179] [INFO] Killing all processes in /dev/ttyACM3
+[2020-08-27 16:17:16,462] [silk.Dev-C179] [INFO] Stopping all processes in /dev/ttyACM3
 [2020-08-27 16:17:16,462] [silk.Dev-C179] [INFO] Getting PIDs for network namespace for /dev/ttyACM3
 [2020-08-27 16:17:16,463] [silk.Dev-C179] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:17:16,463] [silk.Dev-C179] [DEBUG] sudo ip netns pids ttyACM3
@@ -5277,7 +5277,7 @@ output: "Done"
 [2020-08-27 16:17:30,396] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 5, resp: output: "Done"
 [2020-08-27 16:17:30,397] [silk.otnsManager] [DEBUG] Updating nodes layout
 [2020-08-27 16:17:30,397] [silk.Dev-BB23] [INFO] Cleaning up network namespace for /dev/ttyACM7
-[2020-08-27 16:17:30,398] [silk.Dev-BB23] [INFO] Killing all processes in /dev/ttyACM7
+[2020-08-27 16:17:30,398] [silk.Dev-BB23] [INFO] Stopping all processes in /dev/ttyACM7
 [2020-08-27 16:17:30,398] [silk.Dev-BB23] [INFO] Getting PIDs for network namespace for /dev/ttyACM7
 [2020-08-27 16:17:30,398] [silk.Dev-BB23] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:17:30,398] [silk.Dev-BB23] [DEBUG] sudo ip netns pids ttyACM7
@@ -5332,7 +5332,7 @@ output: "Done"
 [2020-08-27 16:17:44,322] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 6, resp: output: "Done"
 [2020-08-27 16:17:44,323] [silk.otnsManager] [DEBUG] Updating nodes layout
 [2020-08-27 16:17:44,323] [silk.Dev-1560] [INFO] Cleaning up network namespace for /dev/ttyACM4
-[2020-08-27 16:17:44,324] [silk.Dev-1560] [INFO] Killing all processes in /dev/ttyACM4
+[2020-08-27 16:17:44,324] [silk.Dev-1560] [INFO] Stopping all processes in /dev/ttyACM4
 [2020-08-27 16:17:44,324] [silk.Dev-1560] [INFO] Getting PIDs for network namespace for /dev/ttyACM4
 [2020-08-27 16:17:44,324] [silk.Dev-1560] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:17:44,324] [silk.Dev-1560] [DEBUG] sudo ip netns pids ttyACM4
@@ -5422,7 +5422,7 @@ output: "Done"
 [2020-08-27 16:17:58,230] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 7, resp: output: "Done"
 [2020-08-27 16:17:58,231] [silk.otnsManager] [DEBUG] Updating nodes layout
 [2020-08-27 16:17:58,231] [silk.Dev-6521] [INFO] Cleaning up network namespace for /dev/ttyACM2
-[2020-08-27 16:17:58,231] [silk.Dev-6521] [INFO] Killing all processes in /dev/ttyACM2
+[2020-08-27 16:17:58,231] [silk.Dev-6521] [INFO] Stopping all processes in /dev/ttyACM2
 [2020-08-27 16:17:58,232] [silk.Dev-6521] [INFO] Getting PIDs for network namespace for /dev/ttyACM2
 [2020-08-27 16:17:58,232] [silk.Dev-6521] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:17:58,232] [silk.Dev-6521] [DEBUG] sudo ip netns pids ttyACM2
@@ -5471,7 +5471,7 @@ output: "Done"
 [2020-08-27 16:18:12,155] [silk.otnsManager.gRPCClient] [INFO] Sending cmd: del 8
 [2020-08-27 16:18:12,167] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 8, resp: output: "Done"
 [2020-08-27 16:18:12,168] [silk.Dev-4F76] [INFO] Cleaning up network namespace for /dev/ttyACM0
-[2020-08-27 16:18:12,168] [silk.Dev-4F76] [INFO] Killing all processes in /dev/ttyACM0
+[2020-08-27 16:18:12,168] [silk.Dev-4F76] [INFO] Stopping all processes in /dev/ttyACM0
 [2020-08-27 16:18:12,168] [silk.Dev-4F76] [INFO] Getting PIDs for network namespace for /dev/ttyACM0
 [2020-08-27 16:18:12,168] [silk.Dev-4F76] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:18:12,169] [silk.Dev-4F76] [DEBUG] sudo ip netns pids ttyACM0

--- a/silk/unit_tests/fixture/neighbor_table_log.txt
+++ b/silk/unit_tests/fixture/neighbor_table_log.txt
@@ -1337,7 +1337,7 @@ output: "Done"
 [2020-08-27 16:19:18,201] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 2, resp: output: "Done"
 [2020-08-27 16:19:18,202] [silk.otnsManager] [DEBUG] Updating nodes layout
 [2020-08-27 16:19:18,202] [silk.Dev-9119] [INFO] Cleaning up network namespace for /dev/ttyACM8
-[2020-08-27 16:19:18,202] [silk.Dev-9119] [INFO] Killing all processes in /dev/ttyACM8
+[2020-08-27 16:19:18,202] [silk.Dev-9119] [INFO] Stopping all processes in /dev/ttyACM8
 [2020-08-27 16:19:18,202] [silk.Dev-9119] [INFO] Getting PIDs for network namespace for /dev/ttyACM8
 [2020-08-27 16:19:18,202] [silk.Dev-9119] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:19:18,202] [silk.Dev-9119] [DEBUG] sudo ip netns pids ttyACM8
@@ -1469,7 +1469,7 @@ output: "Done"
 [2020-08-27 16:19:32,232] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 3, resp: output: "Done"
 [2020-08-27 16:19:32,233] [silk.otnsManager] [DEBUG] Updating nodes layout
 [2020-08-27 16:19:32,233] [silk.Dev-4456] [INFO] Cleaning up network namespace for /dev/ttyACM1
-[2020-08-27 16:19:32,234] [silk.Dev-4456] [INFO] Killing all processes in /dev/ttyACM1
+[2020-08-27 16:19:32,234] [silk.Dev-4456] [INFO] Stopping all processes in /dev/ttyACM1
 [2020-08-27 16:19:32,234] [silk.Dev-4456] [INFO] Getting PIDs for network namespace for /dev/ttyACM1
 [2020-08-27 16:19:32,234] [silk.Dev-4456] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:19:32,235] [silk.Dev-4456] [DEBUG] sudo ip netns pids ttyACM1
@@ -1541,7 +1541,7 @@ output: "Done"
 [2020-08-27 16:19:46,302] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 4, resp: output: "Done"
 [2020-08-27 16:19:46,302] [silk.otnsManager] [DEBUG] Updating nodes layout
 [2020-08-27 16:19:46,303] [silk.Dev-C179] [INFO] Cleaning up network namespace for /dev/ttyACM3
-[2020-08-27 16:19:46,303] [silk.Dev-C179] [INFO] Killing all processes in /dev/ttyACM3
+[2020-08-27 16:19:46,303] [silk.Dev-C179] [INFO] Stopping all processes in /dev/ttyACM3
 [2020-08-27 16:19:46,303] [silk.Dev-C179] [INFO] Getting PIDs for network namespace for /dev/ttyACM3
 [2020-08-27 16:19:46,304] [silk.Dev-C179] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:19:46,304] [silk.Dev-C179] [DEBUG] sudo ip netns pids ttyACM3
@@ -1591,7 +1591,7 @@ output: "Done"
 [2020-08-27 16:20:00,312] [silk.otnsManager.gRPCClient] [INFO] Sending cmd: del 5
 [2020-08-27 16:20:00,323] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 5, resp: output: "Done"
 [2020-08-27 16:20:00,323] [silk.Dev-BB23] [INFO] Cleaning up network namespace for /dev/ttyACM7
-[2020-08-27 16:20:00,324] [silk.Dev-BB23] [INFO] Killing all processes in /dev/ttyACM7
+[2020-08-27 16:20:00,324] [silk.Dev-BB23] [INFO] Stopping all processes in /dev/ttyACM7
 [2020-08-27 16:20:00,324] [silk.Dev-BB23] [INFO] Getting PIDs for network namespace for /dev/ttyACM7
 [2020-08-27 16:20:00,324] [silk.Dev-BB23] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:20:00,325] [silk.Dev-BB23] [DEBUG] sudo ip netns pids ttyACM7

--- a/silk/unit_tests/fixture/partition_merge_log.txt
+++ b/silk/unit_tests/fixture/partition_merge_log.txt
@@ -1665,7 +1665,7 @@ output: "Done"
 [2020-08-27 16:28:58,037] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 2, resp: output: "Done"
 [2020-08-27 16:28:58,037] [silk.otnsManager] [DEBUG] Updating nodes layout
 [2020-08-27 16:28:58,038] [silk.Dev-9119] [INFO] Cleaning up network namespace for /dev/ttyACM8
-[2020-08-27 16:28:58,038] [silk.Dev-9119] [INFO] Killing all processes in /dev/ttyACM8
+[2020-08-27 16:28:58,038] [silk.Dev-9119] [INFO] Stopping all processes in /dev/ttyACM8
 [2020-08-27 16:28:58,038] [silk.Dev-9119] [INFO] Getting PIDs for network namespace for /dev/ttyACM8
 [2020-08-27 16:28:58,039] [silk.Dev-9119] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:28:58,039] [silk.Dev-9119] [DEBUG] sudo ip netns pids ttyACM8
@@ -1717,7 +1717,7 @@ output: "Done"
 [2020-08-27 16:29:11,938] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 3, resp: output: "Done"
 [2020-08-27 16:29:11,938] [silk.otnsManager] [DEBUG] Updating nodes layout
 [2020-08-27 16:29:11,939] [silk.Dev-4456] [INFO] Cleaning up network namespace for /dev/ttyACM1
-[2020-08-27 16:29:11,939] [silk.Dev-4456] [INFO] Killing all processes in /dev/ttyACM1
+[2020-08-27 16:29:11,939] [silk.Dev-4456] [INFO] Stopping all processes in /dev/ttyACM1
 [2020-08-27 16:29:11,939] [silk.Dev-4456] [INFO] Getting PIDs for network namespace for /dev/ttyACM1
 [2020-08-27 16:29:11,940] [silk.Dev-4456] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:29:11,940] [silk.Dev-4456] [DEBUG] sudo ip netns pids ttyACM1
@@ -1768,7 +1768,7 @@ output: "Done"
 [2020-08-27 16:29:25,868] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 4, resp: output: "Done"
 [2020-08-27 16:29:25,868] [silk.otnsManager] [DEBUG] Updating nodes layout
 [2020-08-27 16:29:25,869] [silk.Dev-C179] [INFO] Cleaning up network namespace for /dev/ttyACM3
-[2020-08-27 16:29:25,869] [silk.Dev-C179] [INFO] Killing all processes in /dev/ttyACM3
+[2020-08-27 16:29:25,869] [silk.Dev-C179] [INFO] Stopping all processes in /dev/ttyACM3
 [2020-08-27 16:29:25,869] [silk.Dev-C179] [INFO] Getting PIDs for network namespace for /dev/ttyACM3
 [2020-08-27 16:29:25,869] [silk.Dev-C179] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:29:25,870] [silk.Dev-C179] [DEBUG] sudo ip netns pids ttyACM3
@@ -1818,7 +1818,7 @@ output: "Done"
 [2020-08-27 16:29:39,773] [silk.otnsManager.gRPCClient] [INFO] Sending cmd: del 5
 [2020-08-27 16:29:39,782] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 5, resp: output: "Done"
 [2020-08-27 16:29:39,783] [silk.Dev-BB23] [INFO] Cleaning up network namespace for /dev/ttyACM7
-[2020-08-27 16:29:39,783] [silk.Dev-BB23] [INFO] Killing all processes in /dev/ttyACM7
+[2020-08-27 16:29:39,783] [silk.Dev-BB23] [INFO] Stopping all processes in /dev/ttyACM7
 [2020-08-27 16:29:39,784] [silk.Dev-BB23] [INFO] Getting PIDs for network namespace for /dev/ttyACM7
 [2020-08-27 16:29:39,784] [silk.Dev-BB23] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:29:39,784] [silk.Dev-BB23] [DEBUG] sudo ip netns pids ttyACM7

--- a/silk/unit_tests/fixture/router_table_log.txt
+++ b/silk/unit_tests/fixture/router_table_log.txt
@@ -1710,7 +1710,7 @@ output: "Done"
 [2020-08-27 16:21:48,269] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 2, resp: output: "Done"
 [2020-08-27 16:21:48,270] [silk.otnsManager] [DEBUG] Updating nodes layout
 [2020-08-27 16:21:48,270] [silk.Dev-9119] [INFO] Cleaning up network namespace for /dev/ttyACM8
-[2020-08-27 16:21:48,270] [silk.Dev-9119] [INFO] Killing all processes in /dev/ttyACM8
+[2020-08-27 16:21:48,270] [silk.Dev-9119] [INFO] Stopping all processes in /dev/ttyACM8
 [2020-08-27 16:21:48,271] [silk.Dev-9119] [INFO] Getting PIDs for network namespace for /dev/ttyACM8
 [2020-08-27 16:21:48,271] [silk.Dev-9119] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:21:48,271] [silk.Dev-9119] [DEBUG] sudo ip netns pids ttyACM8
@@ -1780,7 +1780,7 @@ output: "Done"
 [2020-08-27 16:22:02,283] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 3, resp: output: "Done"
 [2020-08-27 16:22:02,283] [silk.otnsManager] [DEBUG] Updating nodes layout
 [2020-08-27 16:22:02,284] [silk.Dev-4456] [INFO] Cleaning up network namespace for /dev/ttyACM1
-[2020-08-27 16:22:02,284] [silk.Dev-4456] [INFO] Killing all processes in /dev/ttyACM1
+[2020-08-27 16:22:02,284] [silk.Dev-4456] [INFO] Stopping all processes in /dev/ttyACM1
 [2020-08-27 16:22:02,284] [silk.Dev-4456] [INFO] Getting PIDs for network namespace for /dev/ttyACM1
 [2020-08-27 16:22:02,285] [silk.Dev-4456] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:22:02,285] [silk.Dev-4456] [DEBUG] sudo ip netns pids ttyACM1
@@ -1843,7 +1843,7 @@ output: "Done"
 [2020-08-27 16:22:16,275] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 4, resp: output: "Done"
 [2020-08-27 16:22:16,275] [silk.otnsManager] [DEBUG] Updating nodes layout
 [2020-08-27 16:22:16,276] [silk.Dev-C179] [INFO] Cleaning up network namespace for /dev/ttyACM3
-[2020-08-27 16:22:16,276] [silk.Dev-C179] [INFO] Killing all processes in /dev/ttyACM3
+[2020-08-27 16:22:16,276] [silk.Dev-C179] [INFO] Stopping all processes in /dev/ttyACM3
 [2020-08-27 16:22:16,276] [silk.Dev-C179] [INFO] Getting PIDs for network namespace for /dev/ttyACM3
 [2020-08-27 16:22:16,277] [silk.Dev-C179] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:22:16,277] [silk.Dev-C179] [DEBUG] sudo ip netns pids ttyACM3
@@ -1912,7 +1912,7 @@ output: "Done"
 [2020-08-27 16:22:30,284] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 5, resp: output: "Done"
 [2020-08-27 16:22:30,284] [silk.otnsManager] [DEBUG] Updating nodes layout
 [2020-08-27 16:22:30,285] [silk.Dev-BB23] [INFO] Cleaning up network namespace for /dev/ttyACM7
-[2020-08-27 16:22:30,285] [silk.Dev-BB23] [INFO] Killing all processes in /dev/ttyACM7
+[2020-08-27 16:22:30,285] [silk.Dev-BB23] [INFO] Stopping all processes in /dev/ttyACM7
 [2020-08-27 16:22:30,285] [silk.Dev-BB23] [INFO] Getting PIDs for network namespace for /dev/ttyACM7
 [2020-08-27 16:22:30,286] [silk.Dev-BB23] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:22:30,286] [silk.Dev-BB23] [DEBUG] sudo ip netns pids ttyACM7
@@ -2014,7 +2014,7 @@ output: "Done"
 [2020-08-27 16:22:44,286] [silk.otnsManager.gRPCClient] [INFO] Sending cmd: del 6
 [2020-08-27 16:22:44,294] [silk.otnsManager.gRPCClient] [INFO] Sent cmd: del 6, resp: output: "Done"
 [2020-08-27 16:22:44,295] [silk.Dev-1560] [INFO] Cleaning up network namespace for /dev/ttyACM4
-[2020-08-27 16:22:44,295] [silk.Dev-1560] [INFO] Killing all processes in /dev/ttyACM4
+[2020-08-27 16:22:44,295] [silk.Dev-1560] [INFO] Stopping all processes in /dev/ttyACM4
 [2020-08-27 16:22:44,295] [silk.Dev-1560] [INFO] Getting PIDs for network namespace for /dev/ttyACM4
 [2020-08-27 16:22:44,296] [silk.Dev-1560] [DEBUG] Making system call for netns-pids
 [2020-08-27 16:22:44,296] [silk.Dev-1560] [DEBUG] sudo ip netns pids ttyACM4

--- a/silk/utils/process.py
+++ b/silk/utils/process.py
@@ -34,9 +34,9 @@ class Process(object):
 
     def process_cmd_asyc_end(self, key_word):
         self.stop_thread.set()
-        kill_cmd = "ps -ef | grep '" + key_word + "' | grep -v grep | awk '{print $2}' | xargs kill"
-        print(kill_cmd)
-        os.popen(kill_cmd)
+        stop_cmd = "ps -ef | grep '" + key_word + "' | grep -v grep | awk '{print $2}' | xargs kill"
+        print(stop_cmd)
+        os.popen(stop_cmd)
 
     def process_cmd_asyc(self):
         self.stop_thread = threading.Event()

--- a/silk/utils/process_cleanup.py
+++ b/silk/utils/process_cleanup.py
@@ -27,7 +27,7 @@ def ps_cleanup(usb_port="ALL", logname=LOG_FILE):
     logging.info("#" * 10 + "wpantund and ttyACM process info after tearDownClass" + "#" * 10)
     logging.info(output)
 
-    logging.info("#" * 10 + "Kill all wpantund processes if any " + "#" * 10)
+    logging.info("#" * 10 + "Stop all wpantund processes if any " + "#" * 10)
     output_str = output.decode("utf-8")
     for line in output_str:
         if "sbin/wpantund" in line and (usb_port.upper() == "ALL" or line.split()[-1] == usb_port):
@@ -43,7 +43,7 @@ def ps_cleanup(usb_port="ALL", logname=LOG_FILE):
     logging.info("#" * 10 + "list of network namespaces after tearDownClass" + "#" * 10)
     logging.info(output)
 
-    logging.info("#" * 10 + "Kill all open network namespaces if any " + "#" * 10)
+    logging.info("#" * 10 + "Stop all open network namespaces if any " + "#" * 10)
     netns_list = output.split('\n')[:-1]
     for netns in netns_list:
         if netns != '':

--- a/silk/utils/subprocess_runner.py
+++ b/silk/utils/subprocess_runner.py
@@ -51,7 +51,7 @@ class SubprocessRunner(signal.Publisher, threading.Thread):
         """End subprocess runner.
 
         :param int timeout:
-            the seconds to wait before force killing the process
+            the seconds to wait before force stopping the process
         """
         if self.running:
             self.running = False


### PR DESCRIPTION
Move to use respectful terms in our `lintrc` file. The `pylint` package has not been updated so `extension-pkg-whitelist` key has been removed since we do not use it.